### PR TITLE
Fix intermediate_dir variable in test fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -60,14 +60,14 @@ def run_process_data(input_dir: Path, root_dir: Path, do_demo: bool = True, do_r
         ValueError: If the command fails.
     """
 
-    interemediate_dir = root_dir / "intermediate"
+    intermediate_dir = root_dir / "intermediate"
     output_dir = root_dir / "output"
 
     run_and_check(
         [
             "MEICAR_process_data",
             f"input_dir={input_dir!s}",
-            f"intermediate_dir={interemediate_dir!s}",
+            f"intermediate_dir={intermediate_dir!s}",
             f"output_dir={output_dir!s}",
             f"do_demo={do_demo}",
             f"do_reshard={do_reshard}",


### PR DESCRIPTION
## Summary
- correct typo when defining intermediate_dir in `conftest.py`
- update usage of the new variable

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684075ed5f90832cbc5c3150ff6e042c