### PR TITLE
Fix FileExistsError message

### DIFF
--- a/src/MEDS_EIC_AR/__main__.py
+++ b/src/MEDS_EIC_AR/__main__.py
@@ -66,7 +66,7 @@ def pretrain(cfg: DictConfig):
             ckpt_path = find_checkpoint_path(output_dir)
         else:
             raise FileExistsError(
-                "Output directory {output_dir} already exists and is populated. "
+                f"Output directory {output_dir} already exists and is populated. "
                 "Use `do_overwrite` or `do_resume` to proceed."
             )
     else:


### PR DESCRIPTION
## Summary
- interpolate output path in error message

## Testing
- `pytest -q` *(fails: ProxyError while trying to download from huggingface)*

------
https://chatgpt.com/codex/tasks/task_e_684075ede778832cbe56226080ec66a0