### PR TITLE
Add wandb tag instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,36 @@ follows:
 
 ```
 
+### Logging with wandb
+
+You can activate the wandb logger by overriding the trainer logger to `wandb`:
+
+```bash
+MEICAR_pretrain trainer.logger=wandb
+```
+
+The configuration file [`configs/trainer/logger/wandb.yaml`](src/MEDS_EIC_AR/configs/trainer/logger/wandb.yaml)
+exposes a `tags` field. Hydra makes the selected configuration groups available
+via `hydra.runtime.choices`. These can be referenced to automatically tag the
+run. For example:
+
+```yaml
+tags:
+  - ${hydra:runtime.choices.lightning_module/model}
+```
+
+This automatically tags each run with the selected model size (e.g. `small`,
+`medium`, `large`). Hydra currently cannot append to a list with a default
+value. To add your own tags you must override the list and include the default
+tag yourself:
+
+```bash
+MEICAR_pretrain trainer.logger=wandb \
+  trainer.logger.tags="[${hydra:runtime.choices.lightning_module/model},experiment-1]"
+```
+
+This results in the tags `[model_size, "experiment-1"]` being sent to wandb.
+
 ## Output Files
 
 The output files of the pre-training step are stored in the directory specified by the `output_dir` parameter

--- a/src/MEDS_EIC_AR/configs/trainer/logger/wandb.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/logger/wandb.yaml
@@ -9,5 +9,6 @@ log_model: False # upload lightning ckpts
 prefix: "" # a string to put at the beginning of metric keys
 # entity: "" # set to name of your wandb team
 group: ""
-tags: []
+tags:
+  - ${hydra:runtime.choices.lightning_module/model}
 job_type: ""


### PR DESCRIPTION
## Summary
- document how to enable wandb logging and automatically tag runs via Hydra
- show example in the `wandb.yaml` logger config
- clarify in the README that users must override the tags list if they want additional tags

## Testing
- `pre-commit run --files README.md src/MEDS_EIC_AR/configs/trainer/logger/wandb.yaml` *(fails: CONNECT tunnel failed)*
- `pytest -q` *(interrupted, no tests run)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6840b7f42038832cb26566791c2e216f