### PR TITLE
Fix distributed logging

### DIFF
--- a/src/MEDS_EIC_AR/training/module.py
+++ b/src/MEDS_EIC_AR/training/module.py
@@ -225,11 +225,22 @@ class MEICARModule(L.LightningModule):
 
         is_train = stage == train_split
 
-        self.log(f"{stage}/loss", loss, on_step=is_train, on_epoch=True, prog_bar=True, batch_size=batch_size)
+        sync_dist = not is_train and torch.distributed.is_available() and torch.distributed.is_initialized()
+
+        self.log(
+            f"{stage}/loss",
+            loss,
+            on_step=is_train,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+            sync_dist=sync_dist,
+        )
         self.log_dict(
             {f"{stage}/{k}": v for k, v in self.metrics(outputs.logits, batch).items()},
             batch_size=batch_size,
             on_step=is_train,
+            sync_dist=sync_dist,
         )
 
     def training_step(self, batch: MEDSTorchBatch):


### PR DESCRIPTION
## Summary
- in `MEICARModule._log_metrics`, compute `sync_dist` when not training and distributed is active
- pass `sync_dist` to log calls

## Testing
- `ruff check`
- `pytest -q` *(fails: ProxyError connecting to huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_6841a27e45c8832c97e3ae9a8be96d3f