### PR TITLE
Add experiment id helpers and generation speed logging

### DIFF
--- a/src/MEDS_EIC_AR/__main__.py
+++ b/src/MEDS_EIC_AR/__main__.py
@@ -19,6 +19,7 @@ from .training import MEICARModule, find_checkpoint_path, validate_resume_direct
 
 # Import OmegaConf Resolvers
 from .utils import (
+    apply_saved_logger_run_ids,
     gpus_available,
     hash_based_seed,
     int_prod,
@@ -27,6 +28,7 @@ from .utils import (
     num_gpus,
     oc_min,
     resolve_generation_context_size,
+    save_logger_run_ids,
     save_resolved_config,
     sub,
 )
@@ -89,6 +91,7 @@ def pretrain(cfg: DictConfig):
     if M.model.do_demo or cfg.get("seed", None):
         seed_everything(cfg.get("seed", 1), workers=True)
 
+    apply_saved_logger_run_ids(cfg.trainer, output_dir)
     trainer = instantiate(cfg.trainer)
     if any(is_mlflow_logger(logger) for logger in trainer.loggers):
         # We do the import only here to avoid importing mlflow if it isn't installed.
@@ -105,6 +108,7 @@ def pretrain(cfg: DictConfig):
         trainer_kwargs["ckpt_path"] = ckpt_path
 
     trainer.fit(**trainer_kwargs)
+    save_logger_run_ids(trainer.loggers, output_dir)
 
     best_ckpt_path = Path(trainer.checkpoint_callback.best_model_path)
     if not best_ckpt_path.is_file():
@@ -131,6 +135,7 @@ def generate_trajectories(cfg: DictConfig):
     M = MEICARModule.load_from_checkpoint(Path(cfg.ckpt_path))
     M.eval()
 
+    apply_saved_logger_run_ids(cfg.trainer, Path(cfg.model_initialization_dir))
     trainer = instantiate(cfg.trainer)
 
     inference = cfg.inference
@@ -167,4 +172,5 @@ def generate_trajectories(cfg: DictConfig):
             predictions_df = format_trajectories(dataloader.dataset, predictions)
             predictions_df.write_parquet(out_fp, use_pyarrow=True)
 
+    save_logger_run_ids(trainer.loggers, Path(cfg.model_initialization_dir))
     logger.info(f"Generation of trajectories complete in {datetime.now(tz=UTC) - st}")

--- a/src/MEDS_EIC_AR/configs/_demo_generate_trajectories.yaml
+++ b/src/MEDS_EIC_AR/configs/_demo_generate_trajectories.yaml
@@ -2,6 +2,7 @@ defaults:
   - _generate_trajectories
   - override inference: demo
   - override trainer: demo
+  - override trainer/callbacks: generation
   - _self_
 
 do_overwrite: True

--- a/src/MEDS_EIC_AR/configs/_generate_trajectories.yaml
+++ b/src/MEDS_EIC_AR/configs/_generate_trajectories.yaml
@@ -1,6 +1,7 @@
 defaults:
   - datamodule: generate_trajectories
   - trainer: default
+  - override trainer/callbacks: generation
   - inference: default
   - _self_
 

--- a/src/MEDS_EIC_AR/configs/trainer/callbacks/generation.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/callbacks/generation.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - default
+  - generation_speed_logger
+  - _self_
+
+_target_: MEDS_EIC_AR.values_as_list

--- a/src/MEDS_EIC_AR/configs/trainer/callbacks/generation_speed_logger.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/callbacks/generation_speed_logger.yaml
@@ -1,0 +1,2 @@
+generation_speed_logger:
+  _target_: MEDS_EIC_AR.training.callbacks.GenerationSpeedLogger

--- a/src/MEDS_EIC_AR/training/__init__.py
+++ b/src/MEDS_EIC_AR/training/__init__.py
@@ -1,3 +1,4 @@
+from .callbacks import GenerationSpeedLogger
 from .files import find_checkpoint_path, validate_resume_directory
 from .metrics import NextCodeMetrics
 from .module import MEICARModule

--- a/src/MEDS_EIC_AR/training/callbacks.py
+++ b/src/MEDS_EIC_AR/training/callbacks.py
@@ -1,0 +1,37 @@
+import time
+from collections.abc import Sequence
+
+from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.loggers import Logger
+
+
+class GenerationSpeedLogger(Callback):
+    """Logs generation speed statistics during prediction."""
+
+    def on_predict_start(self, trainer, pl_module) -> None:
+        self._epoch_times: list[float] = []
+        self._epoch_start: float | None = None
+
+    def on_predict_epoch_start(self, trainer, pl_module) -> None:
+        self._epoch_start = time.perf_counter()
+
+    def on_predict_epoch_end(self, trainer, pl_module) -> None:
+        if self._epoch_start is None:
+            return
+        self._epoch_times.append(time.perf_counter() - self._epoch_start)
+
+    def on_predict_end(self, trainer, pl_module) -> None:
+        if not self._epoch_times:
+            return
+        avg_epoch_time = sum(self._epoch_times) / len(self._epoch_times)
+        metrics = {"predict/avg_epoch_time_sec": avg_epoch_time}
+        for logger in _ensure_logger_sequence(trainer.loggers):
+            logger.log_metrics(metrics, step=trainer.global_step)
+
+
+def _ensure_logger_sequence(loggers: Logger | Sequence[Logger] | None) -> Sequence[Logger]:
+    if loggers is None:
+        return []
+    if isinstance(loggers, Logger):
+        return [loggers]
+    return list(loggers)

--- a/tests/test_logger_helpers.py
+++ b/tests/test_logger_helpers.py
@@ -1,0 +1,69 @@
+import builtins
+
+from omegaconf import DictConfig
+
+import MEDS_EIC_AR.utils as utils
+
+
+class DummyMLFlowLogger:
+    def __init__(self, run_id="mlflow_run"):
+        self.run_id = run_id
+
+
+class DummyWandBExp:
+    def __init__(self, id="wandb_run"):
+        self.id = id
+
+
+class DummyWandbLogger:
+    def __init__(self, exp_id="wandb_run"):
+        self.experiment = DummyWandBExp(exp_id)
+
+
+def test_apply_saved_logger_run_ids(tmp_path, monkeypatch):
+    cfg = DictConfig(
+        {
+            "loggers": [
+                {"_target_": "MLFlowLogger"},
+                {"_target_": "WandbLogger"},
+            ]
+        }
+    )
+
+    log_dir = tmp_path / "loggers"
+    log_dir.mkdir()
+    (log_dir / "mlflow_run_id.txt").write_text("abc")
+    (log_dir / "wandb_run_id.txt").write_text("xyz")
+
+    utils.apply_saved_logger_run_ids(cfg, tmp_path)
+
+    assert cfg.loggers[0]["run_id"] == "abc"
+    assert cfg.loggers[1]["id"] == "xyz"
+    assert cfg.loggers[1]["resume"] == "allow"
+
+
+def test_save_logger_run_ids(tmp_path, monkeypatch):
+    # Patch lightning logger classes so helpers recognise the dummy objects
+    import importlib
+
+    loggers_mod = importlib.import_module("lightning.pytorch.loggers")
+    monkeypatch.setattr(loggers_mod, "MLFlowLogger", DummyMLFlowLogger, raising=False)
+    monkeypatch.setattr(loggers_mod, "WandbLogger", DummyWandbLogger, raising=False)
+
+    loggers = [DummyMLFlowLogger("mlflow-id"), DummyWandbLogger("wandb-id")]
+    utils.save_logger_run_ids(loggers, tmp_path)
+
+    assert (tmp_path / "loggers" / "mlflow_run_id.txt").read_text() == "mlflow-id"
+    assert (tmp_path / "loggers" / "wandb_run_id.txt").read_text() == "wandb-id"
+
+
+def test_is_wandb_logger_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "lightning.pytorch.loggers" and "WandbLogger" in fromlist:
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert utils.is_wandb_logger(DummyWandbLogger()) is False


### PR DESCRIPTION
## Summary
- create `GenerationSpeedLogger` callback to log predict speed
- allow re-use of MLFlow/WandB run ids via helper functions
- integrate helpers into training and generation scripts
- register new callback only for generation runs

## Testing
- `ruff check .`
- `pytest -q` *(fails: ProxyError when downloading models)*

------
https://chatgpt.com/codex/tasks/task_e_684196455518832c8f64c35153699a39