### PR TITLE
Add experiment id helpers and generation speed logging

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: The dependency group to install (benchmarks, dev, docs)
     required: false
     default: "dev"
+  extras:
+    description: Space-separated list of optional-dependency extras to install (e.g., "mlflow wandb").
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -20,9 +24,13 @@ runs:
       uses: astral-sh/setup-uv@v6
       with:
         enable-cache: true
-        cache-suffix: "py${{ inputs.python-version }}"
+        cache-suffix: "py${{ inputs.python-version }}${{ inputs.extras && format('-{0}', inputs.extras) || '' }}"
 
     - name: Install packages
       shell: bash
       run: |
-        uv sync --locked --group ${{ inputs.group }}
+        extras_args=""
+        for extra in ${{ inputs.extras }}; do
+          extras_args="$extras_args --extra $extra"
+        done
+        uv sync --locked --group ${{ inputs.group }} $extras_args

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,3 +32,29 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
+
+  # Separate job for tests that require optional-dependency extras (``mlflow``, ``wandb``).
+  # Gated from the main test job so a default install stays fast and so the extras' transitive
+  # deps don't poison the main lane's resolution. Integration tests themselves are
+  # ``pytest.importorskip``-gated, so they already skip cleanly in the main job.
+  run_integration_tests_with_optional_extras:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup package with mlflow + wandb extras
+        uses: ./.github/actions/setup
+        with:
+          python-version: "3.12"
+          extras: "mlflow wandb"
+
+      - name: Run integration tests
+        # Offline-by-design: MLflow uses a local ``file://`` tracking URI, WandB runs in
+        # ``WANDB_MODE=offline``. No remote servers are contacted, so this job is safe to run
+        # without credentials and without network flake.
+        env:
+          WANDB_MODE: offline
+        run: >
+          uv run pytest -v tests/test_logger_helpers_integration.py tests/test_logger_helpers.py

--- a/README.md
+++ b/README.md
@@ -229,10 +229,14 @@ follows:
     ├── callbacks
     │   ├── default.yaml
     │   ├── early_stopping.yaml
+    │   ├── generation.yaml
+    │   ├── generation_speed_logger.yaml
     │   ├── learning_rate_monitor.yaml
     │   └── model_checkpoint.yaml
     ├── default.yaml
     ├── demo.yaml
+    ├── demo_generate.yaml
+    ├── generate.yaml
     └── logger
         ├── csv.yaml
         ├── mlflow.yaml

--- a/src/MEDS_EIC_AR/__main__.py
+++ b/src/MEDS_EIC_AR/__main__.py
@@ -295,5 +295,10 @@ def generate_trajectories(cfg: DictConfig):
             pa_table = GeneratedTrajectorySchema.align(predictions_df.to_arrow())
             pq.write_table(pa_table, out_fp)
 
-    save_logger_run_ids(trainer.loggers, Path(cfg.model_initialization_dir))
+    # Save the generation run's logger ids into the *generation* ``output_dir``, not the
+    # training checkpoint's ``model_initialization_dir``. A caller using the escape hatch
+    # described in ``apply_saved_logger_run_ids`` (explicit fresh ``run_id`` for generation)
+    # would otherwise overwrite the training run's saved ids and change what future pretrain-
+    # resume attaches to. Separating the two directories keeps the pretrain save-point frozen.
+    save_logger_run_ids(trainer.loggers, Path(cfg.output_dir))
     logger.info(f"Generation of trajectories complete in {datetime.now(tz=UTC) - st}")

--- a/src/MEDS_EIC_AR/configs/README.md
+++ b/src/MEDS_EIC_AR/configs/README.md
@@ -40,10 +40,14 @@ configuration structure is as follows:
     ├── callbacks
     │   ├── default.yaml
     │   ├── early_stopping.yaml
+    │   ├── generation.yaml
+    │   ├── generation_speed_logger.yaml
     │   ├── learning_rate_monitor.yaml
     │   └── model_checkpoint.yaml
     ├── default.yaml
     ├── demo.yaml
+    ├── demo_generate.yaml
+    ├── generate.yaml
     └── logger
         ├── csv.yaml
         ├── mlflow.yaml

--- a/src/MEDS_EIC_AR/configs/_demo_generate_trajectories.yaml
+++ b/src/MEDS_EIC_AR/configs/_demo_generate_trajectories.yaml
@@ -1,7 +1,7 @@
 defaults:
   - _generate_trajectories
   - override inference: demo
-  - override trainer: demo
+  - override trainer: demo_generate
   - _self_
 
 do_overwrite: True

--- a/src/MEDS_EIC_AR/configs/_generate_trajectories.yaml
+++ b/src/MEDS_EIC_AR/configs/_generate_trajectories.yaml
@@ -1,6 +1,6 @@
 defaults:
   - datamodule: generate_trajectories
-  - trainer: default
+  - trainer: generate
   - inference: default
   - _self_
 

--- a/src/MEDS_EIC_AR/configs/trainer/callbacks/generation.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/callbacks/generation.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - default
+  - generation_speed_logger
+  - _self_
+
+_target_: MEDS_EIC_AR.values_as_list

--- a/src/MEDS_EIC_AR/configs/trainer/callbacks/generation_speed_logger.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/callbacks/generation_speed_logger.yaml
@@ -1,0 +1,2 @@
+generation_speed_logger:
+  _target_: MEDS_EIC_AR.training.callbacks.GenerationSpeedLogger

--- a/src/MEDS_EIC_AR/configs/trainer/demo_generate.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/demo_generate.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - demo
+  - override callbacks: generation
+  - _self_

--- a/src/MEDS_EIC_AR/configs/trainer/generate.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/generate.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - default
+  - override callbacks: generation
+  - _self_

--- a/src/MEDS_EIC_AR/training/__init__.py
+++ b/src/MEDS_EIC_AR/training/__init__.py
@@ -1,3 +1,4 @@
+from .callbacks import GenerationSpeedLogger
 from .files import find_checkpoint_path, validate_resume_directory
 from .metrics import NextCodeMetrics
 from .module import MEICARModule

--- a/src/MEDS_EIC_AR/training/callbacks.py
+++ b/src/MEDS_EIC_AR/training/callbacks.py
@@ -1,0 +1,37 @@
+import time
+from collections.abc import Sequence
+
+from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.loggers import Logger
+
+
+class GenerationSpeedLogger(Callback):
+    """Logs generation speed statistics during prediction."""
+
+    def on_predict_start(self, trainer, pl_module) -> None:
+        self._epoch_times: list[float] = []
+        self._epoch_start: float | None = None
+
+    def on_predict_epoch_start(self, trainer, pl_module) -> None:
+        self._epoch_start = time.perf_counter()
+
+    def on_predict_epoch_end(self, trainer, pl_module) -> None:
+        if self._epoch_start is None:
+            return
+        self._epoch_times.append(time.perf_counter() - self._epoch_start)
+
+    def on_predict_end(self, trainer, pl_module) -> None:
+        if not self._epoch_times:
+            return
+        avg_epoch_time = sum(self._epoch_times) / len(self._epoch_times)
+        metrics = {"predict/avg_epoch_time_sec": avg_epoch_time}
+        for logger in _ensure_logger_sequence(trainer.loggers):
+            logger.log_metrics(metrics, step=trainer.global_step)
+
+
+def _ensure_logger_sequence(loggers: Logger | Sequence[Logger] | None) -> Sequence[Logger]:
+    if loggers is None:
+        return []
+    if isinstance(loggers, Logger):
+        return [loggers]
+    return list(loggers)

--- a/src/MEDS_EIC_AR/training/callbacks.py
+++ b/src/MEDS_EIC_AR/training/callbacks.py
@@ -1,3 +1,4 @@
+import statistics
 import time
 from collections.abc import Sequence
 
@@ -6,11 +7,34 @@ from lightning.pytorch.loggers import Logger
 
 
 class GenerationSpeedLogger(Callback):
-    """Logs generation speed statistics during prediction."""
+    """Logs generation speed statistics (mean + distribution) during prediction.
+
+    Tracks two granularities:
+
+    - **Per-epoch time**, emitted as ``predict/epoch_time_sec_{mean,min,max,std}``. Useful
+      when a single ``trainer.predict`` call iterates multiple dataloaders (e.g., multiple
+      evaluation splits); with only one epoch the min/max/std collapse to the mean / 0 and
+      the signal is in the mean itself.
+    - **Per-batch time**, emitted as ``predict/batch_time_sec_{mean,min,max,std}``. This is
+      where the variance story actually shows up — batch timings fluctuate with sequence
+      length (under rolling generation), GPU warm-up, and device contention. Reporting the
+      distribution (not just the mean) makes it possible to tell "consistently slow" from
+      "occasionally slow" without scraping per-batch logs.
+
+    Additionally emits ``predict/total_time_sec`` (wall-clock across all epochs/batches)
+    and ``predict/num_batches`` as raw counters for downstream computation.
+
+    All metrics are written once per ``trainer.predict`` call via ``on_predict_end`` and
+    rank-gated to ``trainer.is_global_zero`` to avoid duplicated writes in distributed
+    prediction.
+    """
 
     def on_predict_start(self, trainer, pl_module) -> None:
         self._epoch_times: list[float] = []
+        self._batch_times: list[float] = []
         self._epoch_start: float | None = None
+        self._batch_start: float | None = None
+        self._predict_start: float = time.perf_counter()
 
     def on_predict_epoch_start(self, trainer, pl_module) -> None:
         self._epoch_start = time.perf_counter()
@@ -19,20 +43,54 @@ class GenerationSpeedLogger(Callback):
         if self._epoch_start is None:
             return
         self._epoch_times.append(time.perf_counter() - self._epoch_start)
+        self._epoch_start = None
+
+    def on_predict_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx=0) -> None:
+        self._batch_start = time.perf_counter()
+
+    def on_predict_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0) -> None:
+        if self._batch_start is None:
+            return
+        self._batch_times.append(time.perf_counter() - self._batch_start)
+        self._batch_start = None
 
     def on_predict_end(self, trainer, pl_module) -> None:
-        if not self._epoch_times:
+        if not self._epoch_times and not self._batch_times:
             return
         # Rank-gate: in distributed predict, every rank hits ``on_predict_end``. Writing
         # ``log_metrics`` from every rank produces duplicated metric writes and races some
-        # backends (e.g., MLflow), so only rank-zero logs. ``_epoch_times`` measurement itself
-        # is per-rank and independent, which is fine — we just restrict the *write*.
+        # backends (e.g., MLflow), so only rank-zero logs. Measurement itself is per-rank
+        # and independent — we just restrict the *write* side.
         if not trainer.is_global_zero:
             return
-        avg_epoch_time = sum(self._epoch_times) / len(self._epoch_times)
-        metrics = {"predict/avg_epoch_time_sec": avg_epoch_time}
+
+        metrics: dict[str, float | int] = {
+            "predict/total_time_sec": time.perf_counter() - self._predict_start,
+            "predict/num_batches": len(self._batch_times),
+        }
+        metrics.update(_summary_stats("predict/epoch_time_sec", self._epoch_times))
+        metrics.update(_summary_stats("predict/batch_time_sec", self._batch_times))
+
         for logger in _ensure_logger_sequence(trainer.loggers):
             logger.log_metrics(metrics, step=trainer.global_step)
+
+
+def _summary_stats(prefix: str, values: Sequence[float]) -> dict[str, float]:
+    """Return ``{prefix}_{mean,min,max,std}`` for a sequence, or ``{}`` if empty.
+
+    ``std`` is the population standard deviation (``statistics.pstdev``), which is defined
+    even for a single data point (yields 0.0) — we use it rather than ``stdev`` so callers
+    don't need to special-case the 1-sample epoch case. With an empty list we emit nothing
+    so the downstream ``log_metrics`` call doesn't write garbage zeros.
+    """
+    if not values:
+        return {}
+    return {
+        f"{prefix}_mean": statistics.fmean(values),
+        f"{prefix}_min": min(values),
+        f"{prefix}_max": max(values),
+        f"{prefix}_std": statistics.pstdev(values),
+    }
 
 
 def _ensure_logger_sequence(loggers: Logger | Sequence[Logger] | None) -> Sequence[Logger]:

--- a/src/MEDS_EIC_AR/training/callbacks.py
+++ b/src/MEDS_EIC_AR/training/callbacks.py
@@ -23,6 +23,12 @@ class GenerationSpeedLogger(Callback):
     def on_predict_end(self, trainer, pl_module) -> None:
         if not self._epoch_times:
             return
+        # Rank-gate: in distributed predict, every rank hits ``on_predict_end``. Writing
+        # ``log_metrics`` from every rank produces duplicated metric writes and races some
+        # backends (e.g., MLflow), so only rank-zero logs. ``_epoch_times`` measurement itself
+        # is per-rank and independent, which is fine — we just restrict the *write*.
+        if not trainer.is_global_zero:
+            return
         avg_epoch_time = sum(self._epoch_times) / len(self._epoch_times)
         metrics = {"predict/avg_epoch_time_sec": avg_epoch_time}
         for logger in _ensure_logger_sequence(trainer.loggers):

--- a/src/MEDS_EIC_AR/utils.py
+++ b/src/MEDS_EIC_AR/utils.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+from collections.abc import Sequence
 from hashlib import sha256
 from pathlib import Path
 
@@ -21,6 +22,38 @@ def is_mlflow_logger(logger: Logger) -> bool:
         from lightning.pytorch.loggers import MLFlowLogger
 
         return isinstance(logger, MLFlowLogger)
+    except ImportError:
+        return False
+
+
+def is_wandb_logger(logger: Logger) -> bool:
+    """Check whether a Lightning logger is a WandB logger.
+
+    The import of :class:`~lightning.pytorch.loggers.WandbLogger` may fail if
+    the optional ``wandb`` dependency is not installed. This helper safely
+    returns ``False`` in that situation.
+
+    Example:
+        >>> class DummyLogger:
+        ...     ...
+        >>> is_wandb_logger(DummyLogger())
+        False
+        >>> import builtins
+        >>> from unittest.mock import patch
+        >>> original_import = builtins.__import__
+        >>> def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        ...     if name == "lightning.pytorch.loggers" and "WandbLogger" in fromlist:
+        ...         raise ImportError
+        ...     return original_import(name, globals, locals, fromlist, level)
+        >>> with patch.object(builtins, "__import__", fake_import):
+        ...     is_wandb_logger(DummyLogger())
+        False
+    """
+
+    try:
+        from lightning.pytorch.loggers import WandbLogger
+
+        return isinstance(logger, WandbLogger)
     except ImportError:
         return False
 
@@ -356,3 +389,92 @@ def save_resolved_config(cfg: DictConfig, fp: Path) -> bool:
     except Exception as e:
         logger.warning(f"Could not save resolved config: {e}")
         return False
+
+
+def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
+    """Populate logger configs with saved experiment IDs if present.
+
+    This helper mutates the provided trainer configuration in-place and reads
+    any saved run IDs from ``<run_dir>/loggers``. It is kept separate from
+    OmegaConf resolvers so configuration loading remains straightforward.
+
+    Example:
+        >>> from yaml_to_disk import yaml_disk
+        >>> cfg = DictConfig(
+        ...     {"loggers": [{"_target_": "MLFlowLogger"}, {"_target_": "WandbLogger"}]}
+        ... )
+        >>> disk = '''
+        ... loggers:
+        ...   "mlflow_run_id.txt": abc
+        ...   "wandb_run_id.txt": xyz
+        ... '''
+        >>> with yaml_disk(disk) as run_dir:
+        ...     apply_saved_logger_run_ids(cfg, run_dir)
+        ...     print(cfg.loggers[0]["run_id"], cfg.loggers[1]["id"], cfg.loggers[1]["resume"])
+        abc xyz allow
+    """
+
+    if trainer_cfg is None:
+        return
+
+    loggers = []
+    if "logger" in trainer_cfg:
+        loggers.append(trainer_cfg.logger)
+    if "loggers" in trainer_cfg:
+        loggers.extend(trainer_cfg.loggers)
+
+    log_dir = Path(run_dir) / "loggers"
+
+    for logger_cfg in loggers:
+        target = str(logger_cfg.get("_target_", "")).lower()
+        if "wandb" in target:
+            fp = log_dir / "wandb_run_id.txt"
+            if fp.is_file() and not logger_cfg.get("id"):
+                logger_cfg["id"] = fp.read_text().strip()
+                logger_cfg.setdefault("resume", "allow")
+        elif "mlflow" in target:
+            fp = log_dir / "mlflow_run_id.txt"
+            if fp.is_file() and not logger_cfg.get("run_id"):
+                logger_cfg["run_id"] = fp.read_text().strip()
+
+
+def save_logger_run_ids(loggers: Sequence[Logger], run_dir: Path) -> None:
+    """Save experiment IDs for MLFlow and WandB loggers.
+
+    Args:
+        loggers: Collection of :class:`~lightning.pytorch.loggers.Logger` objects
+            used during the run.
+        run_dir: Directory where run IDs should be stored.
+
+    Example:
+        >>> class DummyMLFlowLogger:
+        ...     def __init__(self, run_id="foo"):
+        ...         self.run_id = run_id
+        >>> class DummyWandBExp:
+        ...     def __init__(self, id="bar"):
+        ...         self.id = id
+        >>> class DummyWandbLogger:
+        ...     def __init__(self, exp_id="bar"):
+        ...         self.experiment = DummyWandBExp(exp_id)
+        >>> from unittest.mock import patch
+        >>> from yaml_to_disk import yaml_disk
+        >>> with patch("lightning.pytorch.loggers.MLFlowLogger", DummyMLFlowLogger, create=True), \
+        ...      patch("lightning.pytorch.loggers.WandbLogger", DummyWandbLogger, create=True), \
+        ...      yaml_disk("") as run_dir:
+        ...     save_logger_run_ids([DummyMLFlowLogger("mlflow"), DummyWandbLogger("wandb")], run_dir)
+        ...     print((run_dir / "loggers" / "mlflow_run_id.txt").read_text())
+        ...     print((run_dir / "loggers" / "wandb_run_id.txt").read_text())
+        mlflow
+        wandb
+    """
+
+    log_dir = Path(run_dir) / "loggers"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    for logger in loggers:
+        if is_mlflow_logger(logger):
+            (log_dir / "mlflow_run_id.txt").write_text(str(logger.run_id))
+            continue
+
+        if is_wandb_logger(logger):
+            (log_dir / "wandb_run_id.txt").write_text(str(logger.experiment.id))

--- a/src/MEDS_EIC_AR/utils.py
+++ b/src/MEDS_EIC_AR/utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import torch
 from lightning.pytorch.loggers import Logger
 from MEDS_transforms.configs.utils import OmegaConfResolver
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 logger = logging.getLogger(__name__)
 
@@ -451,11 +451,25 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
     if trainer_cfg is None:
         return
 
-    loggers = []
+    # Lightning accepts ``logger: bool | Logger | Iterable[Logger]``; Hydra lets users disable
+    # logging entirely with ``trainer.logger=false`` or ``trainer.logger=null``. Normalize all
+    # three cases into a flat list of dict-like configs before we start indexing with ``.get``.
+    # Anything non-mapping (``True``/``False``/``None``, concrete Logger instances from Hydra
+    # ``_target_`` resolution — though this helper usually runs *before* instantiation, it can
+    # also be called on already-resolved configs) is skipped silently.
+    raw_entries: list = []
     if "logger" in trainer_cfg:
-        loggers.append(trainer_cfg.logger)
+        raw_entries.append(trainer_cfg.logger)
     if "loggers" in trainer_cfg:
-        loggers.extend(trainer_cfg.loggers)
+        loggers_field = trainer_cfg.loggers
+        if isinstance(loggers_field, DictConfig | dict):
+            raw_entries.append(loggers_field)
+        elif isinstance(loggers_field, list | ListConfig):
+            raw_entries.extend(loggers_field)
+        # Any other shape (bool, None, concrete object) is just a single non-mapping entry;
+        # the ``hasattr`` guard below skips it.
+
+    loggers = [e for e in raw_entries if e is not None and hasattr(e, "get")]
 
     log_dir = Path(run_dir) / "loggers"
 

--- a/src/MEDS_EIC_AR/utils.py
+++ b/src/MEDS_EIC_AR/utils.py
@@ -456,12 +456,19 @@ def save_logger_run_ids(loggers: Sequence[Logger], run_dir: Path) -> None:
         >>> class DummyWandbLogger:
         ...     def __init__(self, exp_id="bar"):
         ...         self.experiment = DummyWandBExp(exp_id)
+        >>> import tempfile
         >>> from unittest.mock import patch
-        >>> from yaml_to_disk import yaml_disk
-        >>> with patch("lightning.pytorch.loggers.MLFlowLogger", DummyMLFlowLogger, create=True), \
-        ...      patch("lightning.pytorch.loggers.WandbLogger", DummyWandbLogger, create=True), \
-        ...      yaml_disk("") as run_dir:
-        ...     save_logger_run_ids([DummyMLFlowLogger("mlflow"), DummyWandbLogger("wandb")], run_dir)
+        >>> mlflow_patch = patch(
+        ...     "lightning.pytorch.loggers.MLFlowLogger", DummyMLFlowLogger, create=True
+        ... )
+        >>> wandb_patch = patch(
+        ...     "lightning.pytorch.loggers.WandbLogger", DummyWandbLogger, create=True
+        ... )
+        >>> with mlflow_patch, wandb_patch, tempfile.TemporaryDirectory() as tmp:
+        ...     run_dir = Path(tmp)
+        ...     save_logger_run_ids(
+        ...         [DummyMLFlowLogger("mlflow"), DummyWandbLogger("wandb")], run_dir
+        ...     )
         ...     print((run_dir / "loggers" / "mlflow_run_id.txt").read_text())
         ...     print((run_dir / "loggers" / "wandb_run_id.txt").read_text())
         mlflow

--- a/src/MEDS_EIC_AR/utils.py
+++ b/src/MEDS_EIC_AR/utils.py
@@ -415,17 +415,37 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
         abc file:///tmp/mlruns_original
         xyz allow
 
-    A caller who explicitly set ``tracking_uri`` in the current config wins — the saved value
-    is only restored when the field is absent. This is the escape hatch for "yes, log into a
-    new store" while keeping the default "resume into the original store" behavior:
+    The restore is all-or-nothing: when we apply a saved ``run_id``, we also override
+    ``tracking_uri`` with the saved value — including when the current config sets
+    ``tracking_uri`` to something else (the default ``configs/trainer/logger/mlflow.yaml``
+    does). That is intentional: resuming a ``run_id`` in a store it wasn't created in is
+    incoherent (the run doesn't exist there), and the repo default interpolates
+    ``tracking_uri`` off the current ``${log_dir}``, so without this override a resumed run
+    would 404 or log to a new store.
 
         >>> cfg = DictConfig(
-        ...     {"loggers": [{"_target_": "MLFlowLogger", "tracking_uri": "file:///tmp/new_store"}]}
+        ...     {"loggers": [{"_target_": "MLFlowLogger", "tracking_uri": "file:///tmp/default_store"}]}
         ... )
         >>> with yaml_disk(disk) as run_dir:
         ...     apply_saved_logger_run_ids(cfg, run_dir)
         ...     print(cfg.loggers[0]["run_id"], cfg.loggers[0]["tracking_uri"])
-        abc file:///tmp/new_store
+        abc file:///tmp/mlruns_original
+
+    To log a new run into a different store (no resume), set ``run_id`` explicitly in the
+    current config — that suppresses the saved-``run_id`` restore, which in turn suppresses
+    the saved-``tracking_uri`` restore:
+
+        >>> cfg = DictConfig(
+        ...     {"loggers": [{
+        ...         "_target_": "MLFlowLogger",
+        ...         "run_id": "fresh",
+        ...         "tracking_uri": "file:///tmp/new_store",
+        ...     }]}
+        ... )
+        >>> with yaml_disk(disk) as run_dir:
+        ...     apply_saved_logger_run_ids(cfg, run_dir)
+        ...     print(cfg.loggers[0]["run_id"], cfg.loggers[0]["tracking_uri"])
+        fresh file:///tmp/new_store
     """
 
     if trainer_cfg is None:
@@ -448,17 +468,26 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
                 logger_cfg.setdefault("resume", "allow")
         elif "mlflow" in target:
             fp = log_dir / "mlflow_run_id.txt"
+            applied_saved_run_id = False
             if fp.is_file() and not logger_cfg.get("run_id"):
                 logger_cfg["run_id"] = fp.read_text().strip()
-            # Restore ``tracking_uri`` too. An MLflow ``run_id`` is only resolvable against the
-            # tracking store it was created in — in this repo the default tracking_uri is derived
-            # from ``${log_dir}`` (i.e. the current run's ``output_dir``), so reusing a saved
-            # run_id in a fresh output dir without also restoring the original tracking_uri sends
-            # the resumed run to the wrong store (or 404s). If the caller explicitly set
-            # ``tracking_uri`` in the current config, we don't override it — that's the escape
-            # hatch for "yes, I really do want to log into a new store." See PR #73 review.
+                applied_saved_run_id = True
+            # Restore ``tracking_uri`` whenever we just applied a saved ``run_id``, overriding
+            # whatever the current config had there. An MLflow ``run_id`` is only resolvable
+            # against the tracking store it was created in; the in-repo default
+            # (``configs/trainer/logger/mlflow.yaml``) sets ``tracking_uri: ${log_dir}/mlflow/mlruns``,
+            # which derives from the *current* run's ``output_dir``, so gating the restore on
+            # ``not logger_cfg.get("tracking_uri")`` (what this code did initially) would never
+            # fire in the common case — the default already populates the field with the new
+            # run's path, and we'd quietly resume a run_id against the wrong store.
+            #
+            # The escape hatch moves: to log to a different store for a genuinely new run, the
+            # caller leaves ``run_id`` explicitly set (or absent from disk) so the restore above
+            # doesn't fire, and we leave ``tracking_uri`` alone. That's coherent. The opposite —
+            # "resume this run_id, but log to a new store" — is incoherent (the run_id doesn't
+            # exist in the new store), and this code now prevents it by construction.
             tracking_fp = log_dir / "mlflow_tracking_uri.txt"
-            if tracking_fp.is_file() and not logger_cfg.get("tracking_uri"):
+            if tracking_fp.is_file() and applied_saved_run_id:
                 logger_cfg["tracking_uri"] = tracking_fp.read_text().strip()
 
 

--- a/src/MEDS_EIC_AR/utils.py
+++ b/src/MEDS_EIC_AR/utils.py
@@ -405,12 +405,27 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
         >>> disk = '''
         ... loggers:
         ...   "mlflow_run_id.txt": abc
+        ...   "mlflow_tracking_uri.txt": file:///tmp/mlruns_original
         ...   "wandb_run_id.txt": xyz
         ... '''
         >>> with yaml_disk(disk) as run_dir:
         ...     apply_saved_logger_run_ids(cfg, run_dir)
-        ...     print(cfg.loggers[0]["run_id"], cfg.loggers[1]["id"], cfg.loggers[1]["resume"])
-        abc xyz allow
+        ...     print(cfg.loggers[0]["run_id"], cfg.loggers[0]["tracking_uri"])
+        ...     print(cfg.loggers[1]["id"], cfg.loggers[1]["resume"])
+        abc file:///tmp/mlruns_original
+        xyz allow
+
+    A caller who explicitly set ``tracking_uri`` in the current config wins — the saved value
+    is only restored when the field is absent. This is the escape hatch for "yes, log into a
+    new store" while keeping the default "resume into the original store" behavior:
+
+        >>> cfg = DictConfig(
+        ...     {"loggers": [{"_target_": "MLFlowLogger", "tracking_uri": "file:///tmp/new_store"}]}
+        ... )
+        >>> with yaml_disk(disk) as run_dir:
+        ...     apply_saved_logger_run_ids(cfg, run_dir)
+        ...     print(cfg.loggers[0]["run_id"], cfg.loggers[0]["tracking_uri"])
+        abc file:///tmp/new_store
     """
 
     if trainer_cfg is None:
@@ -435,6 +450,16 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
             fp = log_dir / "mlflow_run_id.txt"
             if fp.is_file() and not logger_cfg.get("run_id"):
                 logger_cfg["run_id"] = fp.read_text().strip()
+            # Restore ``tracking_uri`` too. An MLflow ``run_id`` is only resolvable against the
+            # tracking store it was created in — in this repo the default tracking_uri is derived
+            # from ``${log_dir}`` (i.e. the current run's ``output_dir``), so reusing a saved
+            # run_id in a fresh output dir without also restoring the original tracking_uri sends
+            # the resumed run to the wrong store (or 404s). If the caller explicitly set
+            # ``tracking_uri`` in the current config, we don't override it — that's the escape
+            # hatch for "yes, I really do want to log into a new store." See PR #73 review.
+            tracking_fp = log_dir / "mlflow_tracking_uri.txt"
+            if tracking_fp.is_file() and not logger_cfg.get("tracking_uri"):
+                logger_cfg["tracking_uri"] = tracking_fp.read_text().strip()
 
 
 def save_logger_run_ids(loggers: Sequence[Logger], run_dir: Path) -> None:
@@ -480,6 +505,16 @@ def save_logger_run_ids(loggers: Sequence[Logger], run_dir: Path) -> None:
     for logger in loggers:
         if is_mlflow_logger(logger):
             (log_dir / "mlflow_run_id.txt").write_text(str(logger.run_id))
+            # Persist ``tracking_uri`` too so ``apply_saved_logger_run_ids`` can attach the
+            # resumed run back to the store it was created in. Attribute is
+            # ``_tracking_uri`` (private) on Lightning's MLFlowLogger; fall back to any
+            # public ``tracking_uri`` if a future Lightning version exposes one. Missing
+            # attribute is survivable — the resume call will work in the common case where
+            # the current tracking_uri happens to match the saved one, and fail with a
+            # clear error otherwise.
+            tracking_uri = getattr(logger, "_tracking_uri", None) or getattr(logger, "tracking_uri", None)
+            if tracking_uri:
+                (log_dir / "mlflow_tracking_uri.txt").write_text(str(tracking_uri))
             continue
 
         if is_wandb_logger(logger):

--- a/src/MEDS_EIC_AR/utils.py
+++ b/src/MEDS_EIC_AR/utils.py
@@ -390,6 +390,27 @@ def save_resolved_config(cfg: DictConfig, fp: Path) -> bool:
         return False
 
 
+def _read_saved_id(fp: Path) -> str | None:
+    """Read a saved-id file defensively; return ``None`` if the file is missing, unreadable, or blank.
+
+    Called by :func:`apply_saved_logger_run_ids` for every ``mlflow_run_id.txt`` /
+    ``wandb_run_id.txt`` / ``mlflow_tracking_uri.txt`` lookup. Treating an empty or
+    whitespace-only file as "no saved id" matches user intent: a sentinel with no content
+    shouldn't silently poison downstream logger instantiation with an invalid ``run_id=""``.
+    I/O errors (permission denied, concurrent delete, disk failures) are logged at warning
+    level and treated as "no saved id" — the caller's run proceeds with the pre-restore
+    config rather than crashing before any compute has run.
+    """
+    if not fp.is_file():
+        return None
+    try:
+        content = fp.read_text().strip()
+    except OSError as e:
+        logger.warning(f"Could not read saved logger id at {fp}: {e}. Skipping restore.")
+        return None
+    return content or None
+
+
 def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
     """Populate logger configs with saved experiment IDs if present.
 
@@ -477,14 +498,16 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
         target = str(logger_cfg.get("_target_", "")).lower()
         if "wandb" in target:
             fp = log_dir / "wandb_run_id.txt"
-            if fp.is_file() and not logger_cfg.get("id"):
-                logger_cfg["id"] = fp.read_text().strip()
+            saved = _read_saved_id(fp)
+            if saved and not logger_cfg.get("id"):
+                logger_cfg["id"] = saved
                 logger_cfg.setdefault("resume", "allow")
         elif "mlflow" in target:
             fp = log_dir / "mlflow_run_id.txt"
             applied_saved_run_id = False
-            if fp.is_file() and not logger_cfg.get("run_id"):
-                logger_cfg["run_id"] = fp.read_text().strip()
+            saved = _read_saved_id(fp)
+            if saved and not logger_cfg.get("run_id"):
+                logger_cfg["run_id"] = saved
                 applied_saved_run_id = True
             # Restore ``tracking_uri`` whenever we just applied a saved ``run_id``, overriding
             # whatever the current config had there. An MLflow ``run_id`` is only resolvable
@@ -500,9 +523,10 @@ def apply_saved_logger_run_ids(trainer_cfg: DictConfig, run_dir: Path) -> None:
             # doesn't fire, and we leave ``tracking_uri`` alone. That's coherent. The opposite —
             # "resume this run_id, but log to a new store" — is incoherent (the run_id doesn't
             # exist in the new store), and this code now prevents it by construction.
-            tracking_fp = log_dir / "mlflow_tracking_uri.txt"
-            if tracking_fp.is_file() and applied_saved_run_id:
-                logger_cfg["tracking_uri"] = tracking_fp.read_text().strip()
+            if applied_saved_run_id:
+                saved_uri = _read_saved_id(log_dir / "mlflow_tracking_uri.txt")
+                if saved_uri:
+                    logger_cfg["tracking_uri"] = saved_uri
 
 
 def save_logger_run_ids(loggers: Sequence[Logger], run_dir: Path) -> None:

--- a/tests/test_logger_helpers.py
+++ b/tests/test_logger_helpers.py
@@ -1,0 +1,69 @@
+import builtins
+
+from omegaconf import DictConfig
+
+import MEDS_EIC_AR.utils as utils
+
+
+class DummyMLFlowLogger:
+    def __init__(self, run_id="mlflow_run"):
+        self.run_id = run_id
+
+
+class DummyWandBExp:
+    def __init__(self, id="wandb_run"):
+        self.id = id
+
+
+class DummyWandbLogger:
+    def __init__(self, exp_id="wandb_run"):
+        self.experiment = DummyWandBExp(exp_id)
+
+
+def test_apply_saved_logger_run_ids(tmp_path, monkeypatch):
+    cfg = DictConfig(
+        {
+            "loggers": [
+                {"_target_": "MLFlowLogger"},
+                {"_target_": "WandbLogger"},
+            ]
+        }
+    )
+
+    log_dir = tmp_path / "loggers"
+    log_dir.mkdir()
+    (log_dir / "mlflow_run_id.txt").write_text("abc")
+    (log_dir / "wandb_run_id.txt").write_text("xyz")
+
+    utils.apply_saved_logger_run_ids(cfg, tmp_path)
+
+    assert cfg.loggers[0]["run_id"] == "abc"
+    assert cfg.loggers[1]["id"] == "xyz"
+    assert cfg.loggers[1]["resume"] == "allow"
+
+
+def test_save_logger_run_ids(tmp_path, monkeypatch):
+    # Patch lightning logger classes so helpers recognise the dummy objects
+    import importlib
+
+    loggers_mod = importlib.import_module("lightning.pytorch.loggers")
+    monkeypatch.setattr(loggers_mod, "MLFlowLogger", DummyMLFlowLogger, raising=False)
+    monkeypatch.setattr(loggers_mod, "WandbLogger", DummyWandbLogger, raising=False)
+
+    loggers = [DummyMLFlowLogger("mlflow-id"), DummyWandbLogger("wandb-id")]
+    utils.save_logger_run_ids(loggers, tmp_path)
+
+    assert (tmp_path / "loggers" / "mlflow_run_id.txt").read_text() == "mlflow-id"
+    assert (tmp_path / "loggers" / "wandb_run_id.txt").read_text() == "wandb-id"
+
+
+def test_is_wandb_logger_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "lightning.pytorch.loggers" and "WandbLogger" in fromlist:
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert utils.is_wandb_logger(DummyWandbLogger()) is False

--- a/tests/test_logger_helpers.py
+++ b/tests/test_logger_helpers.py
@@ -80,6 +80,36 @@ def test_apply_saved_logger_run_ids_overrides_default_mlflow_tracking_uri(tmp_pa
     assert cfg.loggers[1]["resume"] == "allow"
 
 
+def test_apply_saved_logger_run_ids_handles_disabled_logger(tmp_path):
+    """``trainer.logger=false`` / ``trainer.logger=null`` must not crash.
+
+    Lightning accepts ``logger: bool | Logger | Iterable[Logger]``. A Hydra user who disables
+    logging via ``trainer.logger=false`` would have previously tripped an ``AttributeError``
+    inside this helper when it tried ``logger_cfg.get("_target_", "")`` on a bool. The
+    normalization step now skips non-mapping entries silently.
+    """
+    log_dir = tmp_path / "loggers"
+    log_dir.mkdir()
+    (log_dir / "mlflow_run_id.txt").write_text("abc")
+
+    # Case: single logger disabled via bool.
+    cfg_bool = DictConfig({"logger": False})
+    utils.apply_saved_logger_run_ids(cfg_bool, tmp_path)  # does not raise
+
+    # Case: single logger disabled via null.
+    cfg_null = DictConfig({"logger": None})
+    utils.apply_saved_logger_run_ids(cfg_null, tmp_path)
+
+    # Case: ``loggers`` key holds a bool rather than a list.
+    cfg_list_bool = DictConfig({"loggers": False})
+    utils.apply_saved_logger_run_ids(cfg_list_bool, tmp_path)
+
+    # Case: mixed — real dict entry alongside a null entry in the list; real entry still patched.
+    cfg_mixed = DictConfig({"loggers": [None, {"_target_": "MLFlowLogger"}]})
+    utils.apply_saved_logger_run_ids(cfg_mixed, tmp_path)
+    assert cfg_mixed.loggers[1]["run_id"] == "abc"
+
+
 def test_apply_saved_logger_run_ids_preserves_explicit_run_id(tmp_path):
     """If the caller explicitly set ``run_id``, neither ``run_id`` nor ``tracking_uri`` is restored.
 
@@ -146,22 +176,44 @@ def test_generation_speed_logger_logs_once_on_rank_zero():
             self.is_global_zero = is_global_zero
             self.global_step = global_step
 
-    # Rank-zero happy path: one epoch, one metric written.
+    # Rank-zero happy path: one epoch with two batches → all mean/min/max/std metrics written.
     rec = RecordingLogger()
     cb = GenerationSpeedLogger()
     trainer = FakeTrainer(loggers=[rec])
     cb.on_predict_start(trainer, pl_module=None)
     cb.on_predict_epoch_start(trainer, pl_module=None)
+    cb.on_predict_batch_start(trainer, pl_module=None, batch=None, batch_idx=0)
+    cb.on_predict_batch_end(trainer, pl_module=None, outputs=None, batch=None, batch_idx=0)
+    cb.on_predict_batch_start(trainer, pl_module=None, batch=None, batch_idx=1)
+    cb.on_predict_batch_end(trainer, pl_module=None, outputs=None, batch=None, batch_idx=1)
     cb.on_predict_epoch_end(trainer, pl_module=None)
     cb.on_predict_end(trainer, pl_module=None)
 
     assert len(rec.calls) == 1
     metrics, step = rec.calls[0]
-    assert set(metrics) == {"predict/avg_epoch_time_sec"}
-    assert metrics["predict/avg_epoch_time_sec"] >= 0.0
+    expected_keys = {
+        "predict/total_time_sec",
+        "predict/num_batches",
+        "predict/epoch_time_sec_mean",
+        "predict/epoch_time_sec_min",
+        "predict/epoch_time_sec_max",
+        "predict/epoch_time_sec_std",
+        "predict/batch_time_sec_mean",
+        "predict/batch_time_sec_min",
+        "predict/batch_time_sec_max",
+        "predict/batch_time_sec_std",
+    }
+    assert set(metrics) == expected_keys
+    assert metrics["predict/num_batches"] == 2
+    # All time-like values are non-negative; min <= mean <= max for both granularities.
+    for prefix in ("predict/epoch_time_sec", "predict/batch_time_sec"):
+        assert metrics[f"{prefix}_min"] <= metrics[f"{prefix}_mean"] <= metrics[f"{prefix}_max"]
+        assert metrics[f"{prefix}_std"] >= 0.0
+    # Single-epoch case collapses epoch std to 0.0 (population stdev of one sample is 0).
+    assert metrics["predict/epoch_time_sec_std"] == 0.0
     assert step == 42
 
-    # Non-rank-zero path: nothing logged even though epoch times were recorded.
+    # Non-rank-zero path: nothing logged even though epoch/batch times were recorded.
     rec2 = RecordingLogger()
     cb2 = GenerationSpeedLogger()
     trainer2 = FakeTrainer(loggers=[rec2], is_global_zero=False)

--- a/tests/test_logger_helpers.py
+++ b/tests/test_logger_helpers.py
@@ -20,7 +20,7 @@ class DummyWandbLogger:
         self.experiment = DummyWandBExp(exp_id)
 
 
-def test_apply_saved_logger_run_ids(tmp_path, monkeypatch):
+def test_apply_saved_logger_run_ids(tmp_path):
     cfg = DictConfig(
         {
             "loggers": [
@@ -55,6 +55,54 @@ def test_save_logger_run_ids(tmp_path, monkeypatch):
 
     assert (tmp_path / "loggers" / "mlflow_run_id.txt").read_text() == "mlflow-id"
     assert (tmp_path / "loggers" / "wandb_run_id.txt").read_text() == "wandb-id"
+
+
+def test_generation_speed_logger_logs_once_on_rank_zero():
+    """``GenerationSpeedLogger`` writes the avg-epoch-time metric exactly once per predict run.
+
+    Also covers the rank-zero gate added in response to a Copilot review on PR #73: in distributed predict,
+    non-rank-zero trainers must not log.
+    """
+    from MEDS_EIC_AR.training.callbacks import GenerationSpeedLogger
+
+    class RecordingLogger:
+        def __init__(self):
+            self.calls: list[tuple[dict, int | None]] = []
+
+        def log_metrics(self, metrics, step=None):
+            self.calls.append((dict(metrics), step))
+
+    class FakeTrainer:
+        def __init__(self, loggers, is_global_zero=True, global_step=42):
+            self.loggers = loggers
+            self.is_global_zero = is_global_zero
+            self.global_step = global_step
+
+    # Rank-zero happy path: one epoch, one metric written.
+    rec = RecordingLogger()
+    cb = GenerationSpeedLogger()
+    trainer = FakeTrainer(loggers=[rec])
+    cb.on_predict_start(trainer, pl_module=None)
+    cb.on_predict_epoch_start(trainer, pl_module=None)
+    cb.on_predict_epoch_end(trainer, pl_module=None)
+    cb.on_predict_end(trainer, pl_module=None)
+
+    assert len(rec.calls) == 1
+    metrics, step = rec.calls[0]
+    assert set(metrics) == {"predict/avg_epoch_time_sec"}
+    assert metrics["predict/avg_epoch_time_sec"] >= 0.0
+    assert step == 42
+
+    # Non-rank-zero path: nothing logged even though epoch times were recorded.
+    rec2 = RecordingLogger()
+    cb2 = GenerationSpeedLogger()
+    trainer2 = FakeTrainer(loggers=[rec2], is_global_zero=False)
+    cb2.on_predict_start(trainer2, pl_module=None)
+    cb2.on_predict_epoch_start(trainer2, pl_module=None)
+    cb2.on_predict_epoch_end(trainer2, pl_module=None)
+    cb2.on_predict_end(trainer2, pl_module=None)
+
+    assert rec2.calls == []
 
 
 def test_is_wandb_logger_missing(monkeypatch):

--- a/tests/test_logger_helpers.py
+++ b/tests/test_logger_helpers.py
@@ -42,6 +42,74 @@ def test_apply_saved_logger_run_ids(tmp_path):
     assert cfg.loggers[1]["resume"] == "allow"
 
 
+def test_apply_saved_logger_run_ids_overrides_default_mlflow_tracking_uri(tmp_path):
+    """Saved tracking_uri must override a repo-default tracking_uri when a saved run_id is applied.
+
+    Regression guard for the case Copilot flagged on PR #73: the default
+    ``configs/trainer/logger/mlflow.yaml`` sets ``tracking_uri: ${log_dir}/mlflow/mlruns``,
+    which post-interpolation is a truthy non-empty string. A naive "only restore if absent"
+    rule would then never fire, and a resumed ``run_id`` would point at the *new* run's
+    tracking store — 404 on resume, or quiet log-to-wrong-store. The current rule is:
+    when a saved ``run_id`` is applied, the saved ``tracking_uri`` overrides whatever
+    the current config contained. This test locks that rule in against both the default
+    config's tracking_uri and a caller-set tracking_uri.
+    """
+    cfg = DictConfig(
+        {
+            "loggers": [
+                {
+                    "_target_": "MLFlowLogger",
+                    "tracking_uri": str(tmp_path / "current-output" / "mlruns"),
+                },
+                {"_target_": "WandbLogger"},
+            ]
+        }
+    )
+
+    log_dir = tmp_path / "loggers"
+    log_dir.mkdir()
+    (log_dir / "mlflow_run_id.txt").write_text("abc")
+    (log_dir / "mlflow_tracking_uri.txt").write_text(str(tmp_path / "original" / "mlruns"))
+    (log_dir / "wandb_run_id.txt").write_text("xyz")
+
+    utils.apply_saved_logger_run_ids(cfg, tmp_path)
+
+    assert cfg.loggers[0]["run_id"] == "abc"
+    assert cfg.loggers[0]["tracking_uri"] == str(tmp_path / "original" / "mlruns")
+    assert cfg.loggers[1]["id"] == "xyz"
+    assert cfg.loggers[1]["resume"] == "allow"
+
+
+def test_apply_saved_logger_run_ids_preserves_explicit_run_id(tmp_path):
+    """If the caller explicitly set ``run_id``, neither ``run_id`` nor ``tracking_uri`` is restored.
+
+    This is the escape hatch for "log a fresh run into a different MLflow store." Without it,
+    a caller who wants a new run in a new store would always have their ``tracking_uri`` silently
+    overwritten by the saved one when a ``mlflow_tracking_uri.txt`` sits in the run_dir.
+    """
+    cfg = DictConfig(
+        {
+            "loggers": [
+                {
+                    "_target_": "MLFlowLogger",
+                    "run_id": "fresh",
+                    "tracking_uri": str(tmp_path / "new-store" / "mlruns"),
+                },
+            ]
+        }
+    )
+
+    log_dir = tmp_path / "loggers"
+    log_dir.mkdir()
+    (log_dir / "mlflow_run_id.txt").write_text("abc")
+    (log_dir / "mlflow_tracking_uri.txt").write_text(str(tmp_path / "original" / "mlruns"))
+
+    utils.apply_saved_logger_run_ids(cfg, tmp_path)
+
+    assert cfg.loggers[0]["run_id"] == "fresh"
+    assert cfg.loggers[0]["tracking_uri"] == str(tmp_path / "new-store" / "mlruns")
+
+
 def test_save_logger_run_ids(tmp_path, monkeypatch):
     # Patch lightning logger classes so helpers recognise the dummy objects
     import importlib

--- a/tests/test_logger_helpers_integration.py
+++ b/tests/test_logger_helpers_integration.py
@@ -1,0 +1,216 @@
+"""Integration tests for the logger-id save / apply helpers using real ``mlflow`` and ``wandb``.
+
+These exercises run end-to-end against the actual Lightning logger classes — they're the
+sanity check that our save/apply helpers remain compatible with real ``MLFlowLogger`` /
+``WandbLogger`` attribute shapes across upstream versions, not just against the dummy
+classes in ``tests/test_logger_helpers.py``.
+
+**Offline by design**: both backends are configured to write to local files only (MLflow via
+a ``file://`` tracking URI; WandB via ``WandbLogger(offline=True)`` plus ``WANDB_MODE=offline``
+belt-and-braces). No remote servers are contacted. That keeps the tests runnable in CI
+without credentials and without network flake.
+
+**Gated by install**: ``pytest.importorskip`` on both modules means these tests are skipped
+cleanly on a default install. To run them, install the extras:
+
+```
+uv sync --extra mlflow --extra wandb
+```
+
+Then run ``uv run pytest tests/test_logger_helpers_integration.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Guard the whole module behind availability of the optional deps. Done at module level so
+# pytest collection doesn't even try to import Lightning logger classes when the extras
+# aren't installed (avoids noisy import errors that look like test failures).
+pytest.importorskip("mlflow")
+pytest.importorskip("wandb")
+
+from lightning.pytorch.loggers import MLFlowLogger, WandbLogger
+
+import MEDS_EIC_AR.utils as utils
+
+# ---------------------------------------------------------------------------
+# MLflow integration
+# ---------------------------------------------------------------------------
+
+
+def test_mlflow_save_and_apply_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Real ``MLFlowLogger`` → save → apply round-trip, offline via a local ``file://`` URI.
+
+    Creates a real MLflow run with a local tracking store, saves its id + uri via
+    :func:`save_logger_run_ids`, then drives :func:`apply_saved_logger_run_ids` against a
+    fresh ``OmegaConf`` config and asserts both ``run_id`` and ``tracking_uri`` are restored
+    exactly — proving the helper is compatible with Lightning's real ``MLFlowLogger`` attribute
+    layout (run_id, _tracking_uri).
+    """
+    # Quiet noisy mlflow/git integration attempts during test runs.
+    monkeypatch.setenv("MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING", "false")
+    monkeypatch.setenv("GIT_PYTHON_REFRESH", "quiet")
+
+    tracking_uri = f"file://{tmp_path / 'mlruns'}"
+    logger = MLFlowLogger(
+        experiment_name="logger_helpers_integration",
+        tracking_uri=tracking_uri,
+    )
+    # Force run creation so ``.run_id`` is populated (Lightning creates lazily on first log).
+    logger.log_metrics({"sanity": 1.0}, step=0)
+    assert logger.run_id, "MLFlowLogger.run_id should be populated after first log_metrics call"
+
+    # Save under a dedicated pretrain-style dir.
+    pretrain_dir = tmp_path / "pretrain_out"
+    utils.save_logger_run_ids([logger], pretrain_dir)
+
+    saved_run_id = (pretrain_dir / "loggers" / "mlflow_run_id.txt").read_text()
+    saved_uri = (pretrain_dir / "loggers" / "mlflow_tracking_uri.txt").read_text()
+    assert saved_run_id == str(logger.run_id)
+    assert saved_uri == tracking_uri
+
+    # Apply to a fresh config that mimics the default trainer/logger/mlflow.yaml shape —
+    # populated tracking_uri pointing at a DIFFERENT (would-be-new) run's store. Helper must
+    # override it with the saved uri because we're resuming.
+    from omegaconf import DictConfig
+
+    new_run_uri = f"file://{tmp_path / 'new_run_mlruns'}"
+    cfg = DictConfig(
+        {
+            "loggers": [
+                {
+                    "_target_": "lightning.pytorch.loggers.MLFlowLogger",
+                    "tracking_uri": new_run_uri,
+                    "experiment_name": "logger_helpers_integration",
+                }
+            ]
+        }
+    )
+    utils.apply_saved_logger_run_ids(cfg, pretrain_dir)
+
+    assert cfg.loggers[0]["run_id"] == str(logger.run_id)
+    assert cfg.loggers[0]["tracking_uri"] == tracking_uri
+
+
+# ---------------------------------------------------------------------------
+# WandB integration
+# ---------------------------------------------------------------------------
+
+
+def test_wandb_save_and_apply_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Real ``WandbLogger`` → save → apply round-trip, fully offline.
+
+    ``WandbLogger(offline=True)`` plus ``WANDB_MODE=offline`` / ``WANDB_DIR`` env overrides
+    keep all state on local disk with no server contact. ``WandbLogger.experiment.id`` is
+    what our save path reads, so this test is the real attribute-shape check.
+    """
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path / "wandb_state"))
+    monkeypatch.setenv("WANDB_CONFIG_DIR", str(tmp_path / "wandb_cfg"))
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path / "wandb_cache"))
+    monkeypatch.setenv("WANDB_SILENT", "true")
+    # WandB disables its own offline warning banner if this is set.
+    monkeypatch.setenv("WANDB_DISABLE_GIT", "true")
+
+    logger = WandbLogger(
+        project="logger_helpers_integration",
+        save_dir=str(tmp_path / "wandb_save"),
+        offline=True,
+    )
+    # Touch .experiment to actually initialize the run (WandbLogger is lazy).
+    _ = logger.experiment
+    assert logger.experiment.id, "WandbLogger.experiment.id should be populated after init"
+
+    pretrain_dir = tmp_path / "pretrain_out"
+    utils.save_logger_run_ids([logger], pretrain_dir)
+
+    saved_id = (pretrain_dir / "loggers" / "wandb_run_id.txt").read_text()
+    assert saved_id == str(logger.experiment.id)
+
+    from omegaconf import DictConfig
+
+    cfg = DictConfig({"loggers": [{"_target_": "lightning.pytorch.loggers.WandbLogger", "offline": True}]})
+    utils.apply_saved_logger_run_ids(cfg, pretrain_dir)
+
+    assert cfg.loggers[0]["id"] == str(logger.experiment.id)
+    assert cfg.loggers[0]["resume"] == "allow"
+
+    # Explicit teardown — WandB buffers files on exit; with offline mode there's no upload,
+    # but we call finish() anyway so pytest doesn't print noisy shutdown-hook warnings.
+    logger.experiment.finish()
+
+
+# ---------------------------------------------------------------------------
+# Detector regression: is_mlflow_logger / is_wandb_logger against real classes
+# ---------------------------------------------------------------------------
+
+
+def test_is_logger_detectors_match_real_classes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """``is_mlflow_logger`` / ``is_wandb_logger`` must return True for the real classes.
+
+    These are the detectors used in ``save_logger_run_ids`` to decide which file to write.
+    The docstring-level doctests use dummy classes; this test closes the gap against the
+    real Lightning logger implementations (useful when e.g. a Lightning upgrade renames the
+    logger class or changes its module path).
+    """
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path / "wandb_state"))
+    monkeypatch.setenv("WANDB_SILENT", "true")
+
+    mlflow_logger = MLFlowLogger(tracking_uri=f"file://{tmp_path / 'mlruns'}")
+    wandb_logger = WandbLogger(
+        project="detector_test",
+        save_dir=str(tmp_path / "wandb_save"),
+        offline=True,
+    )
+
+    assert utils.is_mlflow_logger(mlflow_logger)
+    assert not utils.is_mlflow_logger(wandb_logger)
+    assert utils.is_wandb_logger(wandb_logger)
+    assert not utils.is_wandb_logger(mlflow_logger)
+
+
+# ---------------------------------------------------------------------------
+# Reliability: corrupted saved-id files must not crash the restore
+# ---------------------------------------------------------------------------
+
+
+def test_corrupted_saved_id_files_do_not_crash(tmp_path: Path):
+    """Empty / whitespace-only saved-id files must be treated as "no saved id", not as empty strings.
+
+    Reliability guard requested in PR #73 review: a zero-byte ``mlflow_run_id.txt`` left over
+    from a failed pretrain must not poison the next run by restoring ``run_id=""`` (which MLflow
+    would reject). The helper reads via ``_read_saved_id`` which returns ``None`` for
+    empty/whitespace content.
+    """
+    del tmp_path  # unused
+    assert importlib.util.find_spec("omegaconf") is not None  # sanity
+    from tempfile import TemporaryDirectory
+
+    from omegaconf import DictConfig
+
+    with TemporaryDirectory() as tmp:
+        run_dir = Path(tmp)
+        log_dir = run_dir / "loggers"
+        log_dir.mkdir()
+        (log_dir / "mlflow_run_id.txt").write_text("")
+        (log_dir / "wandb_run_id.txt").write_text("   \n\t  \n")
+
+        cfg = DictConfig(
+            {
+                "loggers": [
+                    {"_target_": "MLFlowLogger"},
+                    {"_target_": "WandbLogger"},
+                ]
+            }
+        )
+        utils.apply_saved_logger_run_ids(cfg, run_dir)
+
+        # Neither logger should have been touched, because the saved files were blank.
+        assert "run_id" not in cfg.loggers[0]
+        assert "id" not in cfg.loggers[1]
+        assert "resume" not in cfg.loggers[1]


### PR DESCRIPTION
## Summary
- create `GenerationSpeedLogger` callback to log predict speed
- allow re-use of MLFlow/WandB run ids via helper functions
- integrate helpers into training and generation scripts
- register new callback only for generation runs
- fix Hydra defaults order for generation config
- add dedicated `generate` trainers and document logger helpers

## Testing
- `ruff check .`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684196455518832c8f64c35153699a39