### PR TITLE
ci: bump codecov-action to v5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,6 @@ jobs:
           uv run pytest -v --cov=src
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrade `codecov/codecov-action` from the pinned v4.0.1 to v5 (latest stable major).
- Using the major tag lets patch-level updates flow in automatically, matching how most of the other actions in this repo are versioned.

## Test plan
- [ ] CI green on this PR
- [ ] Codecov upload step succeeds and coverage is visible on the Codecov dashboard for this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)