### PR TITLE
ci: pin mdformat plugin versions in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,14 +58,14 @@ repos:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-config
-          - mdformat-mkdocs
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat_frontmatter==2.0.10
+          - mdformat-config==0.2.1
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
## Summary
- Pin each `additional_dependencies` entry under the `mdformat` pre-commit hook to a specific version.
- Previously these were unpinned, so every fresh pre-commit environment (CI runners, new clones) resolved to whatever was on PyPI at install time. A new plugin release with altered formatting rules could silently break builds.
- Pinned to the versions currently known to work alongside the `mdformat 0.7.22` hook (these are what the existing local/CI environments have been using).
- The hook `rev` fields were already pinned, so no flakiness was coming from there; this PR only addresses the unpinned plugin deps.

## Test plan
- [x] `uv run pre-commit run --all-files` — all hooks pass locally with the pinned versions
- [ ] Code Quality PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)