### PR TITLE
Merge dev into main: codecov v5 bump + pre-commit deps pinned

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,6 @@ jobs:
           uv run pytest -v --cov=src
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,14 +58,14 @@ repos:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-config
-          - mdformat-mkdocs
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat_frontmatter==2.0.10
+          - mdformat-config==0.2.1
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
## Summary
- Brings dev into main after #83 and #84 landed.
- \`ci: bump codecov-action to v5\` (#83) — upgrades the Codecov upload action from the pinned v4.0.1 to v5 (latest stable major).
- \`ci: pin mdformat plugin versions in pre-commit config\` (#84) — pins the \`mdformat\` hook's \`additional_dependencies\` list so every fresh pre-commit environment resolves to deterministic versions.

Neither touches runtime code; the diff is scoped to \`.github/workflows/tests.yaml\` and \`.pre-commit-config.yaml\`.

## Test plan
- [x] Both source PRs green on dev
- [ ] \`Tests\` + \`Code Quality Main\` green on this merge PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)