### PR TITLE
ci: emit coverage.xml so codecov stops reporting 'unknown'

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,9 +24,11 @@ jobs:
 
       - name: Run tests
         run: >
-          uv run pytest -v --cov=src
+          uv run pytest -v --cov=src --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Codecov has been showing "unknown" coverage on main because the test workflow runs `pytest --cov=src` without requesting an XML report, so only the binary `.coverage` file exists at the time `codecov-action@v5` runs. With no file to upload, the action silently succeeds but reports nothing, which is exactly the "unknown" state on the dashboard.

## Fix

- Add \`--cov-report=xml\` to the pytest invocation so \`coverage.xml\` is written in the workflow working directory.
- Pass \`files: ./coverage.xml\` explicitly to \`codecov/codecov-action@v5\` so the upload step is deterministic rather than relying on file auto-discovery.
- Set \`fail_ci_if_error: true\` so the next missing-file regression becomes a loud CI failure instead of reverting to "unknown".

## Test plan

- [ ] CI passes on this branch (pytest + doctest suite unchanged).
- [ ] After merge, codecov dashboard populates with a real coverage % on the main branch run.
- [ ] Follow-up: sync through to dev so the fix is also in the rolling-generation base branch and doesn't regress on the next dev → main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)