### PR TITLE
Bump meds-torch-data to >=0.7.0; default pretrain sampling to BALANCED_RANDOM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "pytest",
   "meds_testing_helpers~=0.3.0",
   "MEDS-transforms~=0.5.2",
-  "meds-torch-data[lightning]~=0.6.3",
+  "meds-torch-data[lightning]~=0.7.0",
   "transformers",
   "torch",
   "torchmetrics",

--- a/src/MEDS_EIC_AR/configs/datamodule/pretrain.yaml
+++ b/src/MEDS_EIC_AR/configs/datamodule/pretrain.yaml
@@ -2,6 +2,18 @@ defaults:
   - default
   - _self_
 
+# seq_sampling_strategy controls how subsequences are sampled from each subject's full timeline
+# during training. Options (from meds-torch-data >=0.7.0):
+#   - RANDOM: uniform random start offset. Events near the middle of long sequences appear in
+#     more windows than events at the boundaries (trapezoidal inclusion distribution).
+#   - BALANCED_RANDOM: every event has equal inclusion probability regardless of position.
+#     Draws a (possibly negative) start offset and clips to the sequence, producing shorter
+#     windows near the boundaries. Removes the structural boundary bias of RANDOM.
+#   - FROM_START / TO_END: deterministic, take the first / last max_seq_len elements.
+#   - STEP_THROUGH: deterministic sliding window that expands one subject into multiple
+#     dataset elements. Requires step_through_stride or step_through_overlap to be set.
+# BALANCED_RANDOM is the default for pretraining because it gives uniform per-event coverage
+# without the boundary bias of RANDOM. Override via CLI: datamodule.config.seq_sampling_strategy=RANDOM
 config:
   max_seq_len: ${max_seq_len}
-  seq_sampling_strategy: RANDOM
+  seq_sampling_strategy: BALANCED_RANDOM

--- a/uv.lock
+++ b/uv.lock
@@ -1597,7 +1597,7 @@ requires-dist = [
     { name = "lightning", specifier = "~=2.5.1" },
     { name = "meds", specifier = "~=0.4.0" },
     { name = "meds-testing-helpers", specifier = "~=0.3.0" },
-    { name = "meds-torch-data", extras = ["lightning"], specifier = "~=0.6.3" },
+    { name = "meds-torch-data", extras = ["lightning"], specifier = "~=0.7.0" },
     { name = "meds-trajectory-evaluation", specifier = "~=0.0.3" },
     { name = "meds-transforms", specifier = "~=0.5.2" },
     { name = "mlflow", marker = "extra == 'mlflow'" },
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "meds-torch-data"
-version = "0.6.6"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hydra-core" },
@@ -1658,9 +1658,9 @@ dependencies = [
     { name = "pytest" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/b3/cd0ed3d2f0d203129b1d49691827102b885749f17742735d70af8da872f8/meds_torch_data-0.6.6.tar.gz", hash = "sha256:d46d521ef8a99b314b0c157b12034c6b7f17db5ab4a550e61978c8ba1fe6ec43", size = 236694, upload-time = "2025-11-05T17:09:43.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/52/83c74bd33fa30e1d825c927443f955d11d1cbe21becd5a3776ef8cc3a2e1/meds_torch_data-0.7.0.tar.gz", hash = "sha256:a69690fe9fe808cdc35fc25535972546cb403bdf9eb12f7e83f71029c9900442", size = 258165, upload-time = "2026-04-16T12:51:42.237Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/bd/80f49e9b57f78d76216004f00501143261caa6b4471e5c772e949a438ca6/meds_torch_data-0.6.6-py3-none-any.whl", hash = "sha256:a0b4c539aa02f124165929ddf4ce906800790f1a70a75c4d4817048103209b16", size = 57348, upload-time = "2025-11-05T17:09:41.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b3/18e73362053923a587f800edc1bcc9191bd64b25ddba8e9f6bf0a0598962/meds_torch_data-0.7.0-py3-none-any.whl", hash = "sha256:9a0ef17fa7ab66088bdcb136875ee755878c3b96e392b6099923a44a4f82f643", size = 70882, upload-time = "2026-04-16T12:51:40.551Z" },
 ]
 
 [package.optional-dependencies]
@@ -2001,7 +2001,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2012,7 +2012,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2039,9 +2039,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2052,7 +2052,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3199,6 +3199,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/150fdb96b8fab27fe08d8a59fe67554568727981806e6bc2677a16081ec7/ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539", size = 102394, upload-time = "2025-11-14T21:57:36.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e6/a3fa40084558c7e1dc9546385f22a93949c890a8b2e445b2ba43935f51da/ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008", size = 122673, upload-time = "2025-11-14T21:57:38.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `meds-torch-data[lightning]` from `~=0.6.3` to `~=0.7.0` in `pyproject.toml`.
- Change the pretrain datamodule config's `seq_sampling_strategy` from `RANDOM` to `BALANCED_RANDOM`.
- Document all available strategies inline in the config file.

## Why BALANCED_RANDOM

`meds-torch-data` 0.7.0 adds `SubsequenceSamplingStrategy.BALANCED_RANDOM`, which gives every event in a subject's timeline **equal probability of inclusion** in a training window. The previous default, `RANDOM`, draws start offsets uniformly from `[0, seq_len - max_seq_len]`, producing a trapezoidal per-event inclusion distribution: events near the middle of long sequences appear in roughly `max_seq_len` times as many windows as events at the boundaries. `BALANCED_RANDOM` removes this structural bias by allowing the sampling window to overhang the left or right edge of the sequence (clipped, then padded by the collator downstream).

This is a better default for pretraining because it gives the model more exposure to boundary events (early-timeline and recent-timeline codes) that `RANDOM` undersamples. The strategy is overridable via CLI: `datamodule.config.seq_sampling_strategy=RANDOM`.

The `generate_trajectories` config is unchanged — it stays on `TO_END`, which is appropriate for generation where we always condition on the end of the observed timeline.

## What 0.7.0 adds

- `BALANCED_RANDOM` subsequence sampling (described above).
- `STEP_THROUGH` deterministic sliding-window sampling — walks every permitted subsequence of a subject's timeline in order, expanding one subject into multiple dataset elements. Useful for evaluation / coverage but not the default for pretraining.

## Test plan

- [x] `uv run pytest -q` — 56/56 tests pass locally with `meds-torch-data==0.7.0`.
- [ ] CI passes on this branch.
- [ ] After merge, verify that the pretrain CLI picks up `BALANCED_RANDOM` by default and that it can be overridden to `RANDOM` / `STEP_THROUGH` via Hydra CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)