### PR TITLE
ci: bump pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: "docs/index.md"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -22,7 +22,7 @@ repos:
 
   # python code formatting, linting, and import sorting using ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.15.10
     hooks:
       # Run the formatter
       - id: ruff-format
@@ -32,7 +32,7 @@ repos:
 
   # python docstring formatting
   - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=110, --wrap-descriptions=110]
@@ -47,7 +47,7 @@ repos:
 
   # shell scripts linter
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 
@@ -69,7 +69,7 @@ repos:
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -78,7 +78,7 @@ repos:
 
   # jupyter notebook cell output clearing
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
 

--- a/src/MEDS_EIC_AR/model/model.py
+++ b/src/MEDS_EIC_AR/model/model.py
@@ -282,7 +282,7 @@ class Model(torch.nn.Module):
         if batch.mode != "SM":
             raise ValueError(f"Batch mode {batch.mode} is not supported.")
 
-        batch_size, seq_len = code.shape
+        _batch_size, seq_len = code.shape
 
         if seq_len > self.max_seq_len:
             raise ValueError(


### PR DESCRIPTION
## Summary

Bumps all pre-commit hooks to their latest releases (except mdformat — see below). Fixes one new ruff lint caught by the updated rule set.

## Changes

**Pre-commit hooks updated:**
| Hook | Old | New |
|------|-----|-----|
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| ruff-pre-commit | v0.11.6 | v0.15.10 |
| docformatter | v1.7.5 | v1.7.7 |
| shellcheck-py | v0.10.0.1 | v0.11.0.1 |
| codespell | v2.4.1 | v2.4.2 |
| nbstripout | 0.8.1 | 0.9.1 |

**Skipped:** mdformat kept at 0.7.22. Version 1.0.0 conflicts with `mdformat-tables==1.0.0` which requires `mdformat<0.8.0`. Would need coordinated plugin version bumps; not worth the risk for this PR.

**Code fix:** ruff 0.15.10 adds rule `RUF059` (unused unpacked variable). Caught `batch_size, seq_len = code.shape` in `model.py:285` where `batch_size` was never read. Fixed with `_batch_size` prefix.

## Test plan
- [x] `pre-commit run --all-files` passes locally with all updated hooks.
- [x] `uv run pytest -q` — 56/56 tests pass.
- [ ] CI passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)