### PR TITLE
ci: capture subprocess coverage (70% → 95%)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,20 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Enable subprocess coverage
+        # Without this, the CLI tests (which invoke MEICAR_pretrain /
+        # MEICAR_generate_trajectories via subprocess.run) leave src/MEDS_EIC_AR/__main__.py
+        # and src/MEDS_EIC_AR/preprocessing/__main__.py at 0% coverage even though they're
+        # actually exercised. The .pth file is auto-imported by every Python interpreter,
+        # and coverage.process_startup() reads COVERAGE_PROCESS_START to begin tracking
+        # subprocess coverage. See https://coverage.readthedocs.io/en/latest/subprocess.html
+        run: |
+          SITE_PACKAGES=$(uv run python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
+          echo 'import coverage; coverage.process_startup()' > "$SITE_PACKAGES/cov_subprocess.pth"
+
       - name: Run tests
+        env:
+          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
         run: >
           uv run pytest -v --cov=src --cov-report=xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,15 @@ markers = [
   "parallelized: mark test as parallelized, requiring hydra-joblib-launcher",
 ]
 
+[tool.coverage.run]
+# Enable parallel mode so that subprocess coverage data (from CLI tests that
+# invoke MEICAR_pretrain / MEICAR_generate_trajectories via subprocess.run) is
+# written to separate .coverage.<host>.<pid> files and merged automatically by
+# pytest-cov at the end of the run. Requires COVERAGE_PROCESS_START to be set
+# and a .pth file in site-packages that calls coverage.process_startup().
+parallel = true
+source = ["src/MEDS_EIC_AR"]
+
 [tool.coverage.report]
 exclude_also = ["logger\\.debug", "except ImportError:", "if TYPE_CHECKING:"]
 


### PR DESCRIPTION
## Summary

Coverage was reporting **70%** on `dev` because `conftest.py` runs the CLI entry points (`MEICAR_pretrain`, `MEICAR_generate_trajectories`, `MEICAR_process_data`) via `subprocess.run`, and `pytest-cov` doesn't follow into subprocesses by default. `__main__.py` and `preprocessing/__main__.py` both showed **0%** coverage despite being heavily exercised end-to-end.

The standard fix from [coverage.py's docs](https://coverage.readthedocs.io/en/latest/subprocess.html):

1. `[tool.coverage.run] parallel = true` — each subprocess writes its own `.coverage.<host>.<pid>` file that pytest-cov merges at the end.
2. `source = ["src/MEDS_EIC_AR"]` — same scope as in-process coverage.
3. In CI, drop a one-line `.pth` file into site-packages that calls `coverage.process_startup()`. This runs in every Python interpreter, and `process_startup()` reads `COVERAGE_PROCESS_START` to begin tracking.
4. Set `COVERAGE_PROCESS_START=$workspace/pyproject.toml` as a job env var so subprocesses pick up the right config.

**No test code changes.** Everything is configuration.

## Local results (before / after on `pytest --cov=src/MEDS_EIC_AR`)

| File | Before | After |
|------|--------|-------|
| `__main__.py` | **0%** | **85%** |
| `preprocessing/__main__.py` | **0%** | **100%** |
| `generation/utils.py` | 88% | 100% |
| `training/module.py` | 70% | 93% |
| `model/model.py` | 89% | 94% |
| **TOTAL** | **70%** | **95%** |

## Test plan
- [x] `pytest --cov=src/MEDS_EIC_AR` locally with the `.pth` file installed: 56/56 tests pass, 95% coverage.
- [ ] CI passes on this branch and the codecov upload reflects the new ~95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)