### PR TITLE
ci: simplify subprocess coverage via coverage.py patch option

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,20 +22,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Enable subprocess coverage
-        # Without this, the CLI tests (which invoke MEICAR_pretrain /
-        # MEICAR_generate_trajectories via subprocess.run) leave src/MEDS_EIC_AR/__main__.py
-        # and src/MEDS_EIC_AR/preprocessing/__main__.py at 0% coverage even though they're
-        # actually exercised. The .pth file is auto-imported by every Python interpreter,
-        # and coverage.process_startup() reads COVERAGE_PROCESS_START to begin tracking
-        # subprocess coverage. See https://coverage.readthedocs.io/en/latest/subprocess.html
-        run: |
-          SITE_PACKAGES=$(uv run python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
-          echo 'import coverage; coverage.process_startup()' > "$SITE_PACKAGES/cov_subprocess.pth"
-
       - name: Run tests
-        env:
-          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
+        # Subprocess coverage from the CLI integration tests is captured automatically via
+        # `patch = ["subprocess"]` in pyproject.toml's [tool.coverage.run] section — no
+        # .pth file or COVERAGE_PROCESS_START needed.
         run: >
           uv run pytest -v --cov=src --cov-report=xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,15 @@ markers = [
 ]
 
 [tool.coverage.run]
-# Enable parallel mode so that subprocess coverage data (from CLI tests that
-# invoke MEICAR_pretrain / MEICAR_generate_trajectories via subprocess.run) is
-# written to separate .coverage.<host>.<pid> files and merged automatically by
-# pytest-cov at the end of the run. Requires COVERAGE_PROCESS_START to be set
-# and a .pth file in site-packages that calls coverage.process_startup().
-parallel = true
+# Capture coverage from subprocess-based CLI tests (conftest.py runs
+# MEICAR_pretrain / MEICAR_generate_trajectories / MEICAR_process_data via
+# subprocess.run). coverage.py's built-in "subprocess" patch does the right
+# thing automatically: it monkeypatches subprocess.Popen/spawnv/etc. at
+# coverage-start time so every Python subprocess gets coverage tracking
+# without any .pth file installation or COVERAGE_PROCESS_START env var.
+# Setting `patch = ["subprocess"]` also implies `parallel = true`.
+# See https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html.
+patch = ["subprocess"]
 source = ["src/MEDS_EIC_AR"]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

Per your pointer to [pytest-cov's subprocess-support docs](https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html), there's a much simpler approach than the .pth-file + env-var setup from #101: coverage.py >= 7.10 supports a `patch = [\"subprocess\"]` option that monkeypatches `subprocess.Popen` at coverage-start time to auto-enable tracking in child processes.

## What changed

### pyproject.toml

Before:
\`\`\`toml
[tool.coverage.run]
parallel = true
source = [\"src/MEDS_EIC_AR\"]
\`\`\`

After:
\`\`\`toml
[tool.coverage.run]
patch = [\"subprocess\"]
source = [\"src/MEDS_EIC_AR\"]
\`\`\`

`patch = [\"subprocess\"]` implies `parallel = true` automatically.

### .github/workflows/tests.yaml

Removed the whole \"Enable subprocess coverage\" step (10 lines) plus the `COVERAGE_PROCESS_START` env var on the Run tests step. The \"Run tests\" step is now just `uv run pytest -v --cov=src --cov-report=xml`.

## Why this is strictly better

- **No .pth file in site-packages.** The old approach modified the virtualenv to install `cov_subprocess.pth`, which is the kind of setup CI archaeology that's easy to break.
- **No `COVERAGE_PROCESS_START` env var.** Removes one more invisible-state requirement.
- **Same coverage outcome.** Local verification: 95% total, `__main__.py` at 85%, `preprocessing/__main__.py` at 100% — identical to #101's numbers.
- **One fewer CI step** (the whole pth-file install step is gone).

## Test plan

- [x] `pytest --cov=src/MEDS_EIC_AR` locally with only the pyproject.toml change (no .pth file, no env var): 56/56 tests pass, 95% coverage.
- [ ] CI passes on this branch and codecov reports ~95% on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)