### PR TITLE
fix: preprocessing/__main__.py cleanup (closes #112, #113, #114, #115)

### DIFF
--- a/src/MEDS_EIC_AR/preprocessing/__main__.py
+++ b/src/MEDS_EIC_AR/preprocessing/__main__.py
@@ -1,7 +1,7 @@
-import copy
 import logging
 import os
 import subprocess
+import sys
 from importlib.resources import files
 from pathlib import Path
 
@@ -11,6 +11,35 @@ from omegaconf import DictConfig
 logger = logging.getLogger(__name__)
 
 CONFIGS = files("MEDS_EIC_AR") / "preprocessing" / "configs"
+
+
+def _run_streamed(cmd: list[str], *, env: dict[str, str] | None = None, stage_name: str) -> None:
+    """Run a subprocess, streaming its output live to the parent's stdout/stderr.
+
+    The two MTD stages (``MEDS_transform-pipeline`` and ``MTD_preprocess``) can run for many
+    minutes on real datasets. Previously we used ``subprocess.run(..., capture_output=True)``
+    which buffered the entire stdout/stderr in memory until the child exited — on a several-
+    hour MIMIC-IV preprocessing job this meant zero progress visibility for the user and
+    unbounded parent-process memory growth. Piping straight through to the parent's streams
+    gives real-time progress and keeps memory flat at the cost of only surfacing output as
+    lines are produced (which is what you want for a user-facing CLI).
+
+    Also fixes the asymmetric error-logging pattern the pre-refactor code had: the old
+    MEDS_transform block logged both stdout and stderr on failure, but the MTD_preprocess
+    block only logged stderr, losing Python traceback context. Streaming both to the
+    parent's streams removes that asymmetry entirely — failure output is already visible.
+    """
+    logger.info(f"Running command: {' '.join(cmd)}")
+    # ``stdout`` / ``stderr`` defaulting to ``None`` in subprocess.run means "inherit the
+    # parent's file descriptors," which is the streaming behavior we want. Explicitly naming
+    # ``sys.stdout`` / ``sys.stderr`` so this stays correct under Hydra loggers that have
+    # redirected Python's streams (the underlying OS fd is still the right destination).
+    result = subprocess.run(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr, check=False)
+    if result.returncode != 0:  # pragma: no cover
+        raise RuntimeError(
+            f"{stage_name} failed with exit code {result.returncode}. "
+            "Check the streamed output above for details."
+        )
 
 
 @hydra.main(version_base=None, config_path=str(CONFIGS), config_name="_process_data")
@@ -26,7 +55,10 @@ def process_data(cfg: DictConfig):
     if done_fp.exists():  # pragma: no cover
         logger.info("Pre-MTD pre-processing already done, skipping")
     else:
-        env = copy.deepcopy(os.environ)
+        # ``os.environ`` is ``str -> str``; no nested-mutable values to worry about, so a
+        # shallow copy is sufficient. ``os.environ.copy()`` returns a plain ``dict`` we're
+        # free to mutate without affecting the parent's environment.
+        env = os.environ.copy()
         env["RAW_MEDS_DIR"] = str(input_dir)
         env["MTD_INPUT_DIR"] = str(intermediate_dir)
 
@@ -35,18 +67,11 @@ def process_data(cfg: DictConfig):
             env["MIN_EVENTS_PER_SUBJECT"] = "1"
 
         pipeline_config_fp = (CONFIGS / "_reshard_data.yaml") if cfg.do_reshard else (CONFIGS / "_data.yaml")
-        cmd = [
-            "MEDS_transform-pipeline",
-            f"pipeline_config_fp={pipeline_config_fp!s}",
-        ]
-        logger.info(f"Running command: {' '.join(cmd)}")
-
-        result = subprocess.run(cmd, env=env, capture_output=True, check=False)
-        if result.returncode != 0:  # pragma: no cover
-            logger.error("Error running MEDS_transform-pipeline")
-            logger.error(result.stdout.decode())
-            logger.error(result.stderr.decode())
-            raise RuntimeError("Error running MEDS_transform-pipeline")
+        _run_streamed(
+            ["MEDS_transform-pipeline", f"pipeline_config_fp={pipeline_config_fp!s}"],
+            env=env,
+            stage_name="MEDS_transform-pipeline",
+        )
 
         logger.info("Pre-MTD pre-processing done")
         done_fp.touch()
@@ -58,22 +83,26 @@ def process_data(cfg: DictConfig):
     if done_fp.exists():  # pragma: no cover
         logger.info("MTD pre-processing already done, skipping")
     else:
-        env = copy.deepcopy(os.environ)
-
-        cmd = [
-            "MTD_preprocess",
-            f"MEDS_dataset_dir={intermediate_dir!s}",
-            f"output_dir={output_dir!s}",
-        ]
-        logger.info(f"Running command: {' '.join(cmd)}")
-
-        result = subprocess.run(cmd, env=env, capture_output=True, check=False)
-        if result.returncode != 0:  # pragma: no cover
-            logger.error("Error running MTD_preprocess")
-            logger.error(result.stderr.decode())
-            raise RuntimeError("Error running MTD_preprocess")
+        # This stage doesn't mutate the environment (unlike the Pre-MTD block above, which
+        # adds ``RAW_MEDS_DIR`` / ``MTD_INPUT_DIR``), so pass the parent's ``os.environ``
+        # directly. The earlier copy here was dead code.
+        _run_streamed(
+            [
+                "MTD_preprocess",
+                f"MEDS_dataset_dir={intermediate_dir!s}",
+                f"output_dir={output_dir!s}",
+            ],
+            stage_name="MTD_preprocess",
+        )
 
         logger.info("MTD pre-processing done")
         done_fp.touch()
 
-    return
+
+# ``python -m MEDS_EIC_AR.preprocessing`` goes through this module as ``__main__``. Without
+# this guard, ``@hydra.main`` decorates ``process_data`` but nothing invokes it, so the
+# command silently no-ops. Console-script entrypoints registered in ``pyproject.toml`` call
+# ``process_data`` directly and aren't affected, but ``python -m`` invocation is the
+# standard pattern users expect to work for any single-entrypoint module.
+if __name__ == "__main__":  # pragma: no cover
+    process_data()


### PR DESCRIPTION
## Summary

Four small preprocessing-entrypoint issues, addressed together because they all touch the same ~50 lines in `src/MEDS_EIC_AR/preprocessing/__main__.py`:

- **Closes #112** — long-running stages no longer buffer all stdout/stderr in memory. Switched `subprocess.run(..., capture_output=True)` to a `_run_streamed` helper that pipes the child's output straight through to the parent's streams. Live progress visibility on multi-minute runs; parent memory stays flat.
- **Closes #113** — MTD_preprocess error path no longer drops stdout. The streaming approach from #112 makes the stage-specific error-log blocks obsolete (both stages' output is already visible on failure). Replaced with a uniform "check the streamed output above" message from `_run_streamed`.
- **Closes #114** — `copy.deepcopy(os.environ)` → `os.environ.copy()` (environ is `str → str`, no nested mutables). Dropped the redundant env copy entirely in the MTD_preprocess block since it never mutated the env.
- **Closes #115** — added `if __name__ == "__main__"` guard so `python -m MEDS_EIC_AR.preprocessing` runs the entrypoint instead of silently no-op'ing. Console-script callers from `pyproject.toml` were unaffected; `python -m` invocation is a standard pattern users expect to work.

Dropped the now-unused `copy` import.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/grammar/test_cli.py` — 33 pass
- [x] Manual read of the refactored file; streaming / env / guard semantics are load-bearing for real-dataset runs but aren't covered by doctests. A real `MIMIC-IV` preprocessing run is the meaningful smoke test and happens outside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
