### PR TITLE
chore: trim training-only callbacks from generation bundle (closes #120)

### DIFF
--- a/src/MEDS_EIC_AR/configs/trainer/callbacks/generation.yaml
+++ b/src/MEDS_EIC_AR/configs/trainer/callbacks/generation.yaml
@@ -1,5 +1,10 @@
+# Generation-time callback set. Deliberately does NOT inherit ``default`` because that brings
+# in ``model_checkpoint`` / ``early_stopping`` / ``learning_rate_monitor`` — all training-
+# lifecycle callbacks that don't fire under ``trainer.predict()``. They were inert but visibly
+# present in the config, which misled readers copy-pasting from here into related scenarios
+# (e.g. a future ``score_trajectories`` entrypoint). Keeping only callbacks that actually do
+# something during predict: the speed logger.
 defaults:
-  - default
   - generation_speed_logger
   - _self_
 


### PR DESCRIPTION
## Summary

**Closes #120.** The generation trainer's callback set was inheriting `model_checkpoint` / `early_stopping` / `learning_rate_monitor` from `default.yaml` — all training-lifecycle callbacks whose hooks never fire under `trainer.predict()`. They were inert but visibly present in the config. Dropped `default` from `configs/trainer/callbacks/generation.yaml`'s `defaults` list; kept only `generation_speed_logger`.

ChatGPT called this out as a non-blocking follow-up during PR #73 review. It's non-blocking because the callbacks are dead code under predict, not a correctness issue — but the muddy abstraction is a footgun for anyone copy-pasting from here (a future `score_trajectories` entrypoint would naturally start from this set and inherit a checkpoint callback it can't use).

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/grammar/test_cli.py\` — 33 pass. No test references the training callbacks from a predict context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)