### PR TITLE
chore: drop code/n_occurrences from count_codes stage (closes #52)

### DIFF
--- a/src/MEDS_EIC_AR/preprocessing/configs/_data.yaml
+++ b/src/MEDS_EIC_AR/preprocessing/configs/_data.yaml
@@ -8,8 +8,10 @@ stages:
       timeline_tokens:
         time_unit: years
   - count_codes:
+      # ``filter_measurements`` below only needs ``code/n_subjects`` (via ``min_subjects_per_code``).
+      # ``code/n_occurrences`` was computed here but never consumed — ``fit_quantile_binning``
+      # below recomputes it for the persisted metadata that ``format_trajectories`` reads.
       aggregations:
-        - code/n_occurrences
         - code/n_subjects
     _base_stage: aggregate_code_metadata
   - filter_measurements:

--- a/src/MEDS_EIC_AR/preprocessing/configs/_reshard_data.yaml
+++ b/src/MEDS_EIC_AR/preprocessing/configs/_reshard_data.yaml
@@ -10,8 +10,10 @@ stages:
       timeline_tokens:
         time_unit: years
   - count_codes:
+      # ``filter_measurements`` below only needs ``code/n_subjects`` (via ``min_subjects_per_code``).
+      # ``code/n_occurrences`` was computed here but never consumed — ``fit_quantile_binning``
+      # below recomputes it for the persisted metadata that ``format_trajectories`` reads.
       aggregations:
-        - code/n_occurrences
         - code/n_subjects
     _base_stage: aggregate_code_metadata
   - filter_measurements:


### PR DESCRIPTION
## Summary

**Closes #52.** The `count_codes` stage was computing both `code/n_occurrences` and `code/n_subjects`, but the immediately-downstream `filter_measurements` stage only uses `min_subjects_per_code` — i.e. only `code/n_subjects`. `code/n_occurrences` was never consumed from this aggregation.

Dropped the redundant `code/n_occurrences` from `count_codes` in both `_data.yaml` and `_reshard_data.yaml`. It remains computed later by `fit_quantile_binning` (which persists it into the metadata parquet consumed by `format_trajectories.py:75` for `has_value_prob = row["values/n_occurrences"] / row["code/n_occurrences"]`), so downstream code is unaffected.

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/grammar/test_cli.py\` — 33 pass.
- [x] Confirmed `code/n_occurrences` is still produced where it matters: `fit_quantile_binning` emits it into the persisted metadata; `format_trajectories.py` reads it from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)