### PR TITLE
fix: let subprocess inherit parent fds in preprocessing CLI (refs #127 review)

### DIFF
--- a/src/MEDS_EIC_AR/preprocessing/__main__.py
+++ b/src/MEDS_EIC_AR/preprocessing/__main__.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import subprocess
-import sys
 from importlib.resources import files
 from pathlib import Path
 
@@ -30,11 +29,14 @@ def _run_streamed(cmd: list[str], *, env: dict[str, str] | None = None, stage_na
     parent's streams removes that asymmetry entirely — failure output is already visible.
     """
     logger.info(f"Running command: {' '.join(cmd)}")
-    # ``stdout`` / ``stderr`` defaulting to ``None`` in subprocess.run means "inherit the
-    # parent's file descriptors," which is the streaming behavior we want. Explicitly naming
-    # ``sys.stdout`` / ``sys.stderr`` so this stays correct under Hydra loggers that have
-    # redirected Python's streams (the underlying OS fd is still the right destination).
-    result = subprocess.run(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr, check=False)
+    # Letting ``stdout`` / ``stderr`` default to ``None`` in ``subprocess.run`` means "inherit
+    # the parent process's OS-level file descriptors," which is exactly the streaming behavior
+    # we want. Previously we passed ``sys.stdout`` / ``sys.stderr`` explicitly, but those are
+    # Python-level wrappers that can be swapped by pytest capture, Jupyter notebooks, or any
+    # logging wrapper — in those environments ``sys.stdout`` has no real ``fileno()`` and
+    # ``subprocess.run`` either raises or redirects to an unintended destination. Default
+    # (inherit) is both sufficient and robust to all such wrappers.
+    result = subprocess.run(cmd, env=env, check=False)
     if result.returncode != 0:  # pragma: no cover
         raise RuntimeError(
             f"{stage_name} failed with exit code {result.returncode}. "


### PR DESCRIPTION
## Summary

Small follow-up fix to PR #123's streaming refactor, catching a bug Copilot flagged on the release-candidate PR #127.

**Previous** (from #123):
\`\`\`python
result = subprocess.run(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr, check=False)
\`\`\`

**Bug**: `sys.stdout` and `sys.stderr` are Python-level wrappers that can be swapped by:
- pytest's capture mode (where `sys.stdout` has no real `.fileno()`),
- Jupyter notebooks (which replace both with `OutStream`),
- Any logging library that redirects stdout.

In those environments, `subprocess.run` either raises on `.fileno()` lookup or redirects to an unintended destination (a pytest capture buffer, a notebook cell, etc.).

**Fix**: let `stdout` / `stderr` default to `None` in `subprocess.run`. That inherits the *parent process's OS-level* file descriptors, which is exactly the streaming behavior we wanted for the long-running MTD pipelines and is robust to whatever Python-level wrappers are in play.

Also dropped the now-unused `sys` import.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/grammar/test_cli.py` — 33 pass.
- [x] Change is semantically equivalent for normal interactive / shell invocations (where `sys.stdout.fileno()` would have returned the real parent fd anyway), but now also works under pytest capture / Jupyter / logging-wrapper contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)