### PR TITLE
fix: pin tensor-print precision=3 to absorb FP16 CI flake

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -284,8 +284,10 @@ def _setup_doctest_namespace(
     # Pin torch's tensor-repr to a fixed abbreviation pattern so doctests that print tensors
     # are stable regardless of prior global state. ``MEDSTorchBatch.__repr__`` in
     # ``meds_torchdata`` temporarily lowers threshold/edgeitems and restores defaults, so
-    # collection-order-dependent state would otherwise leak between tests.
-    torch.set_printoptions(edgeitems=1, threshold=50)
+    # collection-order-dependent state would otherwise leak between tests. ``precision=3``
+    # tracks FP16's ~3-decimal-digit mantissa so the last-digit numerical noise that FP16
+    # matmul kernels produce across CI runs does not surface as a diff in the expected repr.
+    torch.set_printoptions(edgeitems=1, threshold=50, precision=3)
     doctest_namespace.update(
         {
             "print_warnings": partial(print_warnings, caplog),

--- a/src/MEDS_EIC_AR/model/model.py
+++ b/src/MEDS_EIC_AR/model/model.py
@@ -90,19 +90,19 @@ class Model(torch.nn.Module):
 
         >>> loss, outputs = model(sample_batch)
         >>> print(loss)
-        tensor(3.6543, dtype=torch.float16, grad_fn=<NllLoss2DBackward0>)
+        tensor(3.654, dtype=torch.float16, grad_fn=<NllLoss2DBackward0>)
         >>> print(f"Outputs have keys: {', '.join(outputs.keys())}")
         Outputs have keys: logits, past_key_values
         >>> print(f"Logits shape: {outputs.logits.shape}")
         Logits shape: torch.Size([2, 9, 39])
         >>> print(outputs.logits)
-        tensor([[[ 0.0026,  ..., -0.0300],
+        tensor([[[ 0.003,  ..., -0.030],
                  ...,
-                 [-0.0084,  ...,  0.0305]],
+                 [-0.008,  ...,  0.030]],
         <BLANKLINE>
-                [[ 0.0026,  ..., -0.0300],
+                [[ 0.003,  ..., -0.030],
                  ...,
-                 [-0.0091,  ...,  0.0359]]], dtype=torch.float16,
+                 [-0.009,  ...,  0.036]]], dtype=torch.float16,
                grad_fn=<UnsafeViewBackward0>)
 
     The model's parameters can be accessed in the normal way. The first named parameter is the token
@@ -111,9 +111,9 @@ class Model(torch.nn.Module):
         >>> sample_param_name, sample_param = next(iter(model.named_parameters()))
         >>> print(f"{sample_param_name} ({sample_param.shape}): {sample_param}")
         HF_model.model.embed_tokens.weight (torch.Size([39, 4])): Parameter containing:
-        tensor([[ 0.0069,  ...,  0.0099],
+        tensor([[ 0.007,  ...,  0.010],
                 ...,
-                [-0.0085,  ...,  0.0032]], dtype=torch.float16, requires_grad=True)
+                [-0.008,  ...,  0.003]], dtype=torch.float16, requires_grad=True)
 
     Let's validate that they have gradients that can be realized via `.backward()` as normal:
 
@@ -121,9 +121,9 @@ class Model(torch.nn.Module):
         Sample parameter grad?: None
         >>> loss.backward()
         >>> print(f"Sample parameter grad?: {sample_param.grad}")
-        Sample parameter grad?: tensor([[ 0.0000,  ...,  0.0000],
+        Sample parameter grad?: tensor([[ 0.000,  ...,  0.000],
                 ...,
-                [-0.1140,  ..., -0.0845]], dtype=torch.float16)
+                [-0.114,  ..., -0.084]], dtype=torch.float16)
 
     With a single backward pass, we should not get any infinite gradients:
 

--- a/src/MEDS_EIC_AR/training/metrics.py
+++ b/src/MEDS_EIC_AR/training/metrics.py
@@ -42,12 +42,12 @@ class TopKMulticlassAccuracy(Metric):
         >>> TopKMulticlassAccuracy(top_k=2, ignore_index=0)(logits, code)
         tensor(1.)
         >>> TopKMulticlassAccuracy(top_k=1, ignore_index=0)(logits, code)
-        tensor(0.6667)
+        tensor(0.667)
         >>> code = torch.LongTensor([[1, 1], [1, 0]])
         >>> TopKMulticlassAccuracy(top_k=1, ignore_index=0)(logits, code)
-        tensor(0.3333)
+        tensor(0.333)
         >>> TopKMulticlassAccuracy(top_k=2, ignore_index=0)(logits, code)
-        tensor(0.6667)
+        tensor(0.667)
         >>> TopKMulticlassAccuracy(top_k=3, ignore_index=0)(logits, code)
         tensor(1.)
         >>> code = torch.LongTensor([[1, 0], [0, 0]])
@@ -149,8 +149,8 @@ class NextCodeMetrics(Metric):
     Then, we can update and compute the metric values:
 
         >>> M(logits, batch)
-        {'Accuracy/top_1': tensor(0.6667), 'Accuracy/top_2': tensor(1.), 'Accuracy/top_3': tensor(1.),
-         'perplexity': tensor(3.1896)}
+        {'Accuracy/top_1': tensor(0.667), 'Accuracy/top_2': tensor(1.), 'Accuracy/top_3': tensor(1.),
+         'perplexity': tensor(3.190)}
 
     You can also run on a single `top_k`:
 


### PR DESCRIPTION
## Summary

- Follow-up to #135. PR #127's CI flaked again on the Model doctest with a 1-ULP FP16 diff (`-0.1140` vs `-0.1141`) on a backward-pass gradient print.
- FP16 has ~3 decimal digits of mantissa. Printing at `precision=4` (default) surfaces last-digit matmul-kernel noise that can differ across CI runs even with the same seed.
- Pin `precision=3` in the autouse `_setup_doctest_namespace` fixture in `conftest.py` and regenerate the affected expected tensor-repr strings.

## Touched doctests

- `src/MEDS_EIC_AR/model/model.py`: `loss`, `outputs.logits`, `embed_tokens.weight`, `sample_param.grad`.
- `src/MEDS_EIC_AR/training/metrics.py`: `TopKMulticlassAccuracy(...)` scalars (`0.6667 → 0.667`, `0.3333 → 0.333`), `NextCodeMetrics.perplexity` (`3.1896 → 3.190`).

## Test plan

- [x] `uv run pytest --doctest-modules src/ -q` — all 40 pass locally
- [ ] CI green
- [ ] After merge: PRs #117, #127, #129 pick up via merge-from-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)