### PR TITLE
fix: detach + move predict_step tensors to CPU before returning (refs #127)

### DIFF
--- a/src/MEDS_EIC_AR/training/module.py
+++ b/src/MEDS_EIC_AR/training/module.py
@@ -497,7 +497,17 @@ class MEICARModule(L.LightningModule):
             - ``subject_idxs``: ``[B]`` long tensor, which base-dataset subject each row came from.
             - ``trajectory_idxs``: ``[B]`` long tensor, which of the N trajectories-per-subject
               each row corresponds to.
+
+        All three tensors are detached and moved to CPU before returning. ``Trainer.predict``
+        accumulates per-batch returns in a Python list across the entire predict run (scaled by
+        ``n_trajectories`` via the expanded dataset), so leaving them on-device would pin per-batch
+        GPU allocations for the full pass and OOM on non-trivial cohorts. Downstream demux and
+        ``format_trajectories`` run on CPU anyway.
         """
         mdata_batch, subject_idxs, trajectory_idxs = batch
         tokens = self.model.generate(mdata_batch, **self.generation_kwargs)
-        return {"tokens": tokens, "subject_idxs": subject_idxs, "trajectory_idxs": trajectory_idxs}
+        return {
+            "tokens": tokens.detach().cpu(),
+            "subject_idxs": subject_idxs.detach().cpu(),
+            "trajectory_idxs": trajectory_idxs.detach().cpu(),
+        }


### PR DESCRIPTION
## Summary

Address Copilot review comment on PR #127 ([id 3108121337](https://github.com/mmcdermott/MEDS_EIC_AR/pull/127#discussion_r3108121337)):
`Trainer.predict` accumulates per-batch return values in a Python list across the entire predict run. With `RepeatedPredictionDataset` expanding the dataset by `n_trajectories`, leaving these tensors on the prediction device pinned per-batch GPU allocations for the full pass, which can OOM on non-trivial cohorts.

Move `tokens`, `subject_idxs`, and `trajectory_idxs` to CPU inside `predict_step` before returning. Downstream demux in `__main__.py` and `format_trajectories` run on CPU anyway, so this costs nothing at the usage site and releases GPU memory batch-by-batch.

## Scope

1-line-ish change to `predict_step` in `src/MEDS_EIC_AR/training/module.py` plus a docstring note calling out the invariant. Targeted at `dev` so it flows into the release-candidate #127 before the merge to `main`.

A larger follow-up on the same theme — `__main__.py`'s `trainer.predict(return_predictions=False)` + callback-writer streaming refactor — is tracked in the sibling Copilot comment ([id 3108121350](https://github.com/mmcdermott/MEDS_EIC_AR/pull/127#discussion_r3108121350)) and intentionally out of scope for this PR to keep the change auditable for the release window. Filed as a follow-up issue.

## Test plan

- [x] `uv run pytest --doctest-modules src/MEDS_EIC_AR/training/module.py` — 8 passed
- [ ] CI green on this PR

Refs #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)