### PR TITLE
fix: filter rare codes before adding timeline delta tokens (closes #126)

### DIFF
--- a/src/MEDS_EIC_AR/preprocessing/configs/_data.yaml
+++ b/src/MEDS_EIC_AR/preprocessing/configs/_data.yaml
@@ -2,17 +2,13 @@ input_dir: ${oc.env:RAW_MEDS_DIR}
 output_dir: ${oc.env:MTD_INPUT_DIR}
 
 stages:
-  - add_time_derived_measurements:
-      age: null
-      time_of_day: null
-      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
-      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
-      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
-      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
-      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
-      # the whole vocabulary.
-      timeline_tokens:
-        time_unit: years
+  # Stage-order note (issue #126): rare-code and rare-subject filtering must run *before*
+  # ``add_time_derived_measurements``. Timeline delta tokens are inserted between consecutive
+  # events, so inserting them first and filtering after leaves back-to-back
+  # ``TIMELINE//DELTA//*`` tokens wherever the event between two deltas was dropped — a
+  # transition the model can never see at generation time, and one that skews the delta
+  # quantiles short. Filtering first makes each delta the gap between two *kept* events, which
+  # is the quantity an autoregressive model over kept tokens actually conditions on.
   - count_codes:
       # ``filter_measurements`` below only needs ``code/n_subjects`` (via ``min_subjects_per_code``).
       # ``code/n_occurrences`` was computed here but never consumed — ``fit_quantile_binning``
@@ -25,9 +21,14 @@ stages:
         - _matcher: # No filter for static measurements
             time:
               present: False
-        - _matcher: # No filter for birth, death, admission, discharge, registration, or time intervals.
+        - _matcher: # No filter for birth, death, admission, discharge, or registration.
+            # ``TIMELINE//*`` codes used to need an exemption here (via a ``.*TIME.*`` clause)
+            # because ``add_time_derived_measurements`` ran first. It now runs after this
+            # stage, so no timeline token exists yet to exempt — and keeping the clause would
+            # silently exempt any *raw* dataset code containing "TIME" from rare-code
+            # filtering, which was never the intent.
             code:
-              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*|.*TIME.*"
+              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*"
         - _matcher:
             time:
               present: True
@@ -35,6 +36,17 @@ stages:
   - filter_subjects:
       min_events_per_subject: ${oc.decode:${oc.env:MIN_EVENTS_PER_SUBJECT,10}}
       min_measurements_per_subject: null
+  - add_time_derived_measurements:
+      age: null
+      time_of_day: null
+      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
+      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
+      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
+      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
+      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
+      # the whole vocabulary.
+      timeline_tokens:
+        time_unit: years
   - fit_quantile_binning:
       aggregations:
         - code/n_occurrences

--- a/src/MEDS_EIC_AR/preprocessing/configs/_reshard_data.yaml
+++ b/src/MEDS_EIC_AR/preprocessing/configs/_reshard_data.yaml
@@ -4,17 +4,13 @@ output_dir: ${oc.env:MTD_INPUT_DIR}
 stages:
   - reshard_to_split:
       n_subjects_per_shard: 10000
-  - add_time_derived_measurements:
-      age: null
-      time_of_day: null
-      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
-      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
-      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
-      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
-      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
-      # the whole vocabulary.
-      timeline_tokens:
-        time_unit: years
+  # Stage-order note (issue #126): rare-code and rare-subject filtering must run *before*
+  # ``add_time_derived_measurements``. Timeline delta tokens are inserted between consecutive
+  # events, so inserting them first and filtering after leaves back-to-back
+  # ``TIMELINE//DELTA//*`` tokens wherever the event between two deltas was dropped — a
+  # transition the model can never see at generation time, and one that skews the delta
+  # quantiles short. Filtering first makes each delta the gap between two *kept* events, which
+  # is the quantity an autoregressive model over kept tokens actually conditions on.
   - count_codes:
       # ``filter_measurements`` below only needs ``code/n_subjects`` (via ``min_subjects_per_code``).
       # ``code/n_occurrences`` was computed here but never consumed — ``fit_quantile_binning``
@@ -27,9 +23,14 @@ stages:
         - _matcher: # No filter for static measurements
             time:
               present: False
-        - _matcher: # No filter for birth, death, admission, discharge, registration, or time intervals.
+        - _matcher: # No filter for birth, death, admission, discharge, or registration.
+            # ``TIMELINE//*`` codes used to need an exemption here (via a ``.*TIME.*`` clause)
+            # because ``add_time_derived_measurements`` ran first. It now runs after this
+            # stage, so no timeline token exists yet to exempt — and keeping the clause would
+            # silently exempt any *raw* dataset code containing "TIME" from rare-code
+            # filtering, which was never the intent.
             code:
-              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*|.*TIME.*"
+              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*"
         - _matcher:
             time:
               present: True
@@ -37,6 +38,17 @@ stages:
   - filter_subjects:
       min_events_per_subject: ${oc.decode:${oc.env:MIN_EVENTS_PER_SUBJECT,10}}
       min_measurements_per_subject: null
+  - add_time_derived_measurements:
+      age: null
+      time_of_day: null
+      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
+      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
+      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
+      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
+      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
+      # the whole vocabulary.
+      timeline_tokens:
+        time_unit: years
   - fit_quantile_binning:
       aggregations:
         - code/n_occurrences


### PR DESCRIPTION
## Summary

Reorders the preprocessing pipeline so rare-code / rare-subject filtering runs **before**
`add_time_derived_measurements`. Closes #126.

Old order (both `_data.yaml` and `_reshard_data.yaml`):

```
add_time_derived_measurements → count_codes → filter_measurements → filter_subjects
  → fit_quantile_binning → bin_numeric_values
```

New order:

```
count_codes → filter_measurements → filter_subjects → add_time_derived_measurements
  → fit_quantile_binning → bin_numeric_values
```

## Why

Delta tokens were computed over the *unfiltered* event stream, and the events sitting between
them were dropped two stages later. The kept sequence therefore contained back-to-back
`TIMELINE//DELTA//*` tokens wherever a rare event had been filtered out:

```
DELTA(1h) → <rare event, dropped> → DELTA(1h) → kept_event
                     becomes
DELTA(1h) → DELTA(1h) → kept_event
```

That teaches the model a `DELTA → DELTA` transition it can never legitimately emit at
generation time, and it fits the delta quantiles over gaps that are systematically shorter than
any gap the model is actually asked to predict. After the reorder, each delta is the gap
between two **kept** events — the quantity an autoregressive model over kept tokens conditions
on.

## Also in this PR

Dropped the `.*TIME.*` clause from the `filter_measurements` match-revise regex. It existed to
exempt `TIMELINE//*` codes from rare-code filtering back when those codes were inserted first.
With the reorder no timeline token exists at that point, so the clause is dead for its intended
purpose — but it would still silently exempt any *raw* dataset code containing "TIME" from
rare-code filtering, which was never the intent. Flagging it explicitly since it's the one part
of this PR that isn't a pure reordering.

## Verification

Built a fixture where every subject alternates a shared code with codes unique to that subject
(so demo-mode filtering at `MIN_SUBJECTS_PER_CODE=2` drops exactly every other event), ran
`MEICAR_process_data` end-to-end, and counted adjacent `TIMELINE//DELTA` pairs per subject:

| | before | after |
| --- | --- | --- |
| Consecutive `TIMELINE//DELTA` pairs | 60 | **0** |
| Deltas dangling before `TIMELINE//END` | present | **none** |
| Delta bin populated | `[0.000057,0.000114)` (30min–1hr) | `[0.000114,0.000342)` (1hr–3hr) |

The bin shift is the expected consequence of the semantics change, not a regression: kept
events in the fixture are two hours apart, and the pipeline now measures that gap instead of
the one-hour gap to the event it was about to discard.

## Tradeoff — this is a one-way door

**Delta semantics change.** A delta now means "time since previous *kept* event" rather than
"time since previous *raw* event". Values get larger and the quantile-bin distribution shifts
right. The existing `custom_bins` (1_minute … 40_years) still span the range, so this is a
redistribution of mass among existing bins, not a coverage problem.

Anyone comparing training runs across this commit will see different loss curves because the
vocab composition shifts. Existing pretrained checkpoints keep their weights, but the
quantile-bin interpretation they were trained against no longer matches what this pipeline
emits. Per #126 this is deliberate and out of scope to migrate.

## Test plan

- [ ] Full suite — deferred to CI on this PR. The pipeline is exercised end-to-end by `tests/test_process_data.py` (both the plain and `do_reshard=True` paths) and by the `tests/grammar/` CLI tests, which run `MEICAR_process_data` → `MEICAR_pretrain` → `MEICAR_generate_trajectories` through these configs. A local run was started but the grammar fixture's 400-epoch CPU pretrain had not finished when this PR was opened; CI is the gate.
- [x] Manual before/after reproduction on the rare-code fixture described above.
- [x] Both configs parse and their stage bodies remain byte-identical to each other.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcHbFRbEJR1AJ25V7XPKro
