### PR TITLE
release: dev → main (preprocessing stage reorder, #126)

### DIFF
--- a/src/MEDS_EIC_AR/preprocessing/configs/_data.yaml
+++ b/src/MEDS_EIC_AR/preprocessing/configs/_data.yaml
@@ -2,17 +2,13 @@ input_dir: ${oc.env:RAW_MEDS_DIR}
 output_dir: ${oc.env:MTD_INPUT_DIR}
 
 stages:
-  - add_time_derived_measurements:
-      age: null
-      time_of_day: null
-      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
-      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
-      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
-      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
-      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
-      # the whole vocabulary.
-      timeline_tokens:
-        time_unit: years
+  # Stage-order note (issue #126): rare-code and rare-subject filtering must run *before*
+  # ``add_time_derived_measurements``. Timeline delta tokens are inserted between consecutive
+  # events, so inserting them first and filtering after leaves back-to-back
+  # ``TIMELINE//DELTA//*`` tokens wherever the event between two deltas was dropped — a
+  # transition the model can never see at generation time, and one that skews the delta
+  # quantiles short. Filtering first makes each delta the gap between two *kept* events, which
+  # is the quantity an autoregressive model over kept tokens actually conditions on.
   - count_codes:
       # ``filter_measurements`` below only needs ``code/n_subjects`` (via ``min_subjects_per_code``).
       # ``code/n_occurrences`` was computed here but never consumed — ``fit_quantile_binning``
@@ -25,9 +21,14 @@ stages:
         - _matcher: # No filter for static measurements
             time:
               present: False
-        - _matcher: # No filter for birth, death, admission, discharge, registration, or time intervals.
+        - _matcher: # No filter for birth, death, admission, discharge, or registration.
+            # ``TIMELINE//*`` codes used to need an exemption here (via a ``.*TIME.*`` clause)
+            # because ``add_time_derived_measurements`` ran first. It now runs after this
+            # stage, so no timeline token exists yet to exempt — and keeping the clause would
+            # silently exempt any *raw* dataset code containing "TIME" from rare-code
+            # filtering, which was never the intent.
             code:
-              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*|.*TIME.*"
+              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*"
         - _matcher:
             time:
               present: True
@@ -35,6 +36,17 @@ stages:
   - filter_subjects:
       min_events_per_subject: ${oc.decode:${oc.env:MIN_EVENTS_PER_SUBJECT,10}}
       min_measurements_per_subject: null
+  - add_time_derived_measurements:
+      age: null
+      time_of_day: null
+      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
+      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
+      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
+      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
+      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
+      # the whole vocabulary.
+      timeline_tokens:
+        time_unit: years
   - fit_quantile_binning:
       aggregations:
         - code/n_occurrences

--- a/src/MEDS_EIC_AR/preprocessing/configs/_reshard_data.yaml
+++ b/src/MEDS_EIC_AR/preprocessing/configs/_reshard_data.yaml
@@ -4,17 +4,13 @@ output_dir: ${oc.env:MTD_INPUT_DIR}
 stages:
   - reshard_to_split:
       n_subjects_per_shard: 10000
-  - add_time_derived_measurements:
-      age: null
-      time_of_day: null
-      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
-      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
-      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
-      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
-      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
-      # the whole vocabulary.
-      timeline_tokens:
-        time_unit: years
+  # Stage-order note (issue #126): rare-code and rare-subject filtering must run *before*
+  # ``add_time_derived_measurements``. Timeline delta tokens are inserted between consecutive
+  # events, so inserting them first and filtering after leaves back-to-back
+  # ``TIMELINE//DELTA//*`` tokens wherever the event between two deltas was dropped — a
+  # transition the model can never see at generation time, and one that skews the delta
+  # quantiles short. Filtering first makes each delta the gap between two *kept* events, which
+  # is the quantity an autoregressive model over kept tokens actually conditions on.
   - count_codes:
       # ``filter_measurements`` below only needs ``code/n_subjects`` (via ``min_subjects_per_code``).
       # ``code/n_occurrences`` was computed here but never consumed — ``fit_quantile_binning``
@@ -27,9 +23,14 @@ stages:
         - _matcher: # No filter for static measurements
             time:
               present: False
-        - _matcher: # No filter for birth, death, admission, discharge, registration, or time intervals.
+        - _matcher: # No filter for birth, death, admission, discharge, or registration.
+            # ``TIMELINE//*`` codes used to need an exemption here (via a ``.*TIME.*`` clause)
+            # because ``add_time_derived_measurements`` ran first. It now runs after this
+            # stage, so no timeline token exists yet to exempt — and keeping the clause would
+            # silently exempt any *raw* dataset code containing "TIME" from rare-code
+            # filtering, which was never the intent.
             code:
-              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*|.*TIME.*"
+              regex: "MEDS_DEATH.*|MEDS_BIRTH.*|.*ADMISSION.*|.*DISCHARGE.*|.*REGISTRATION.*"
         - _matcher:
             time:
               present: True
@@ -37,6 +38,17 @@ stages:
   - filter_subjects:
       min_events_per_subject: ${oc.decode:${oc.env:MIN_EVENTS_PER_SUBJECT,10}}
       min_measurements_per_subject: null
+  - add_time_derived_measurements:
+      age: null
+      time_of_day: null
+      # ``time_unit`` and the default ``time_delta_code`` prefix (``TIMELINE//DELTA``) are
+      # load-bearing for generation: ``src/MEDS_EIC_AR/generation/finalize.py`` parses the unit
+      # out of ``TIMELINE//DELTA//<unit>//...`` codes at finalize time via
+      # ``TIMELINE_DELTA_TOKEN`` and ``_timeline_delta_seconds_per_unit``. Overriding
+      # ``time_delta_code`` is not supported; changing ``time_unit`` must stay consistent across
+      # the whole vocabulary.
+      timeline_tokens:
+        time_unit: years
   - fit_quantile_binning:
       aggregations:
         - code/n_occurrences


### PR DESCRIPTION
## Summary

Single-change release PR. `dev` contains exactly one PR beyond `main`: #157, the preprocessing
stage reorder from #126.

## What's in it

**#157 — filter rare codes before adding timeline delta tokens (closes #126)**

Reorders both preprocessing pipeline configs so rare-code / rare-subject filtering runs before
`add_time_derived_measurements`:

```
count_codes → filter_measurements → filter_subjects → add_time_derived_measurements
  → fit_quantile_binning → bin_numeric_values
```

Previously delta tokens were inserted first and the events between them dropped two stages
later, leaving back-to-back `TIMELINE//DELTA//*` tokens in the training sequence and fitting the
delta quantiles over gaps shorter than any the model is asked to predict. Verified on a
purpose-built rare-code fixture: 60 consecutive-delta pairs before, 0 after.

Also drops the now-dead `.*TIME.*` clause from the `filter_measurements` match-revise regex,
which would otherwise silently exempt any raw dataset code containing "TIME" from rare-code
filtering.

## Heads-up for anyone with in-flight runs

This changes data semantics, not just stage order. A `TIMELINE//DELTA` value now means "time
since previous **kept** event" rather than "time since previous **raw** event". Values get
larger and the quantile-bin distribution shifts right (the existing `custom_bins` still span the
range, so it's a redistribution, not a coverage gap).

Existing pretrained checkpoints keep their weights, but the quantile-bin interpretation they
were trained against no longer matches what this pipeline emits. Loss curves are not comparable
across this commit. Per #126 this is deliberate and migrating old checkpoints is out of scope.

## CI

Green on #157 — `run_tests_ubuntu` (full suite including the `tests/grammar/` end-to-end CLI
tests, which drive `MEICAR_process_data` → `MEICAR_pretrain` → `MEICAR_generate_trajectories`
through these configs), `run_integration_tests_with_optional_extras`, `code-quality`, and the
distribution build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcHbFRbEJR1AJ25V7XPKro
