### PR TITLE
fix: don't refuse generation on cohorts with no train-split labels (closes #160)

### DIFF
--- a/src/MEDS_EIC_AR/__main__.py
+++ b/src/MEDS_EIC_AR/__main__.py
@@ -183,7 +183,16 @@ def generate_trajectories(cfg: DictConfig):
     # blowing up partway through hours of generation — and even a "saturating" decode of such
     # a bin would yield an uninterpretable trajectory, so refusing to start is the right
     # behavior. The fix lives upstream in the bin-reduction stage; this is the downstream guard.
-    validate_timeline_delta_bins_in_int64_range(get_code_metadata(D.train_dataloader().dataset))
+    #
+    # Read the dataset off the datamodule directly rather than via ``D.train_dataloader().dataset``.
+    # All that is wanted here is the dataset object, so ``get_code_metadata`` can reach
+    # ``dataset.config.code_metadata_fp`` — cohort-level metadata that is identical across splits.
+    # Building the *dataloader* additionally constructs a ``RandomSampler`` (``shuffle=True``),
+    # which rejects a zero-length dataset with ``num_samples should be a positive integer value``.
+    # Task cohorts defined only over tuning/held-out subjects have an empty train split and are a
+    # perfectly ordinary thing to run inference on, so going through the dataloader would refuse
+    # them for a reason unrelated to what is being validated.
+    validate_timeline_delta_bins_in_int64_range(get_code_metadata(D.train_dataset))
 
     # Validate rolling-generation config early — before loading the checkpoint and before running any
     # batches — so bad values (zero or negative budgets) fail fast with a clear message instead of

--- a/tests/test_generate_trajectories.py
+++ b/tests/test_generate_trajectories.py
@@ -29,6 +29,7 @@ from meds import held_out_split, train_split, tuning_split
 from meds_torchdata import MEDSTorchBatch, MEDSTorchDataConfig
 from polars.testing import assert_frame_equal
 
+from conftest import run_and_check
 from MEDS_EIC_AR.model.model import Model
 
 
@@ -64,6 +65,77 @@ def test_generate_trajectories_runs(generated_trajectories: Path):
 
         subjects = {samp: set(df["subject_id"]) for samp, df in samps.items()}
         assert subjects["0"] == subjects["1"], f"Subjects in samples for split {sp} do not match!"
+
+
+@pytest.fixture(scope="session")
+def held_out_only_task_labels(
+    preprocessed_dataset_with_task: tuple[Path, Path, str],
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """A task-labels directory whose labels cover only held-out subjects.
+
+    A task defined purely for inference — over tuning and/or held-out subjects, with nothing in train — is an
+    ordinary thing to have, and produces a zero-length train dataset. This fixture builds one by filtering the
+    shared task fixture's labels down to the subjects that landed in the held-out split of the preprocessed
+    cohort.
+    """
+    cohort_dir, task_root_dir, task_name = preprocessed_dataset_with_task
+
+    held_out_schemas = sorted((cohort_dir / "tokenization" / "schemas" / held_out_split).glob("*.parquet"))
+    held_out_subjects = pl.concat([pl.read_parquet(fp).select("subject_id") for fp in held_out_schemas])
+
+    labels = pl.concat([pl.read_parquet(fp) for fp in sorted((task_root_dir / task_name).glob("*.parquet"))])
+    held_out_labels = labels.join(held_out_subjects.unique(), on="subject_id", how="semi")
+    assert not held_out_labels.is_empty(), (
+        "The shared task fixture has no labels on held-out subjects, so this fixture cannot build a "
+        "cohort that is non-empty on held_out and empty on train."
+    )
+
+    out_dir = tmp_path_factory.mktemp("held_out_only_task_labels") / task_name
+    out_dir.mkdir(parents=True)
+    held_out_labels.write_parquet(out_dir / "labels.parquet")
+    return out_dir
+
+
+def test_generate_trajectories_runs_with_no_train_split_labels(
+    pretrained_model: Path,
+    preprocessed_dataset_with_task: tuple[Path, Path, str],
+    held_out_only_task_labels: Path,
+    tmp_path: Path,
+):
+    """Generation must run on a task cohort that has no train-split labels.
+
+    The startup-time ``TIMELINE//DELTA`` bin check only needs the dataset object, so that it can
+    read cohort-level code metadata off ``dataset.config``. Reaching that object through
+    ``train_dataloader()`` also builds a ``RandomSampler``, which rejects a zero-length dataset with
+    ``num_samples should be a positive integer value, but got num_samples=0`` — refusing the whole
+    run over a split it was never going to generate for. Taking ``train_dataset`` directly avoids
+    the sampler entirely while validating exactly the same metadata.
+
+    Asserting on output rather than merely on "the CLI exited 0" matters here: a regression that
+    skipped the validation instead of fixing the access path would also exit 0.
+    """
+    cohort_dir, _, _ = preprocessed_dataset_with_task
+    output_dir = tmp_path / "generated"
+
+    run_and_check(
+        [
+            "MEICAR_generate_trajectories",
+            "--config-name=_demo_generate_trajectories",
+            f"output_dir={output_dir!s}",
+            f"model_initialization_dir={pretrained_model!s}",
+            f"datamodule.config.tensorized_cohort_dir={cohort_dir!s}",
+            f"datamodule.config.task_labels_dir={held_out_only_task_labels!s}",
+            "datamodule.batch_size=2",
+            "trainer=demo",
+            f"inference.generate_for_splits=[{held_out_split}]",
+        ]
+    )
+
+    written = sorted((output_dir / held_out_split).glob("*.parquet"))
+    assert written, f"No trajectories written under {output_dir / held_out_split}."
+    for fp in written:
+        assert len(pl.read_parquet(fp, use_pyarrow=True)) > 0, f"Trajectory file {fp} is empty."
 
 
 def test_generate_trajectories_rolling_runs(


### PR DESCRIPTION
Closes #160.

## Assessment

Confirmed, and the suggested fix is the right one. `MEDSTorchDataModule.train_dataset` is a
`cached_property` that constructs fine on an empty split; only the `DataLoader`/`RandomSampler`
wrapper around it fails.

The check at the top of `generate_trajectories` wants nothing from the dataloader — it needs the
dataset object so `get_code_metadata` can read `dataset.config.code_metadata_fp`, which is
cohort-level metadata identical across splits. Going through `train_dataloader()` additionally built
a `RandomSampler` (`shuffle=True`), which refuses `len(dataset) == 0`. So a task cohort defined only
over tuning/held-out subjects was rejected at startup over a split the run was never going to
generate for.

## Fix

`D.train_dataloader().dataset` → `D.train_dataset`.

## Regression test

`test_generate_trajectories_runs_with_no_train_split_labels` builds a task-labels directory filtered
to the subjects that landed in the held-out split of the preprocessed cohort (so train is empty,
held_out is not), then drives the real CLI over it with `inference.generate_for_splits=[held_out]`.

It asserts on the written trajectory parquets, not just on exit status — a regression that dropped
the bin validation altogether instead of fixing the access path would also exit 0.

Verified both directions: reverting the one-line change fails the test with exactly the reported
error, `ValueError: num_samples should be a positive integer value, but got num_samples=0`.

## Testing

- `uv run pytest --ignore=tests/grammar`: 75 passed, 4 skipped.
- `pre-commit run`: clean.
- Grammar suite left to CI; it is unaffected (its task cohort has train-split labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAbXzaro3Z6PvX5kkJSH2X
