### PR TITLE
fix: record ARM64 distributions in uv.lock (closes #161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,13 @@ Note also that `sglang_demo.yaml` sets `mem_fraction_static: 0.85`, a fraction o
 Spark shares one 128 GB pool between CPU and GPU, so that reserves ~109 GB and leaves the host close to
 the OOM killer; `0.2`–`0.4` is ample for small models.
 
-> [!NOTE]
-> `uv sync --frozen` currently fails on aarch64 hosts: `uv.lock`'s `av` entry records no wheel or sdist,
-> because it was resolved on x86_64 where `av`'s aarch64-only marker is false. Use `uv pip install -e .`
-> until the lockfile is regenerated with an aarch64 resolution environment. See
-> [#161](https://github.com/mmcdermott/MEDS_EIC_AR/issues/161).
+`uv sync --frozen` works on aarch64 hosts because `pyproject.toml` declares
+`tool.uv.required-environments` with the Linux ARM branch, which forces `uv.lock` to carry
+distributions for it. **Keep that setting if you re-lock.** Without it, a dependency reachable only
+under an ARM marker — `av`, pulled in by the `sglang` extra — gets a lock entry with no wheel and no
+sdist, since the resolver never explores that branch on an x86_64 host. `uv sync` on ARM then fails
+with "can't be installed because it doesn't have a source distribution or wheel for the current
+platform".
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,3 +139,21 @@ select = [
 
 [tool.ruff.lint.pep8-naming]
 extend-ignore-names = ["*MEDS*", "F", "L", "M", "D", "LR_*", "*GPT*"]  # Ignore MEDS in variable names
+
+[tool.uv]
+# Force the lock to carry distributions for ARM64 as well as the x86_64 host it is usually
+# resolved on. Without this, a dependency reachable *only* under an ARM marker gets a package
+# stanza with no `sdist` and no `wheels` at all: the resolver never explored that branch, so it
+# recorded nothing to install, and `uv sync` on an ARM host fails with "can't be installed because
+# it doesn't have a source distribution or wheel for the current platform". `av`, pulled in by the
+# `sglang` extra under an aarch64-only marker, hit exactly that on a DGX Spark.
+#
+# `required-environments` rather than `environments`: the latter would *restrict* resolution to the
+# listed set and silently drop support for anything not enumerated (Windows, for one). This only
+# widens what the lock must cover.
+#
+# Only the Linux ARM branch is listed. Adding macOS ARM was tried and rejected: `sglang` publishes
+# no macOS ARM wheels at 0.5.9, so requiring coverage there forks the resolution back to 0.5.2 and
+# drops `mlx-lm`/`mlx-metal` — a 250-line lock churn and a downgrade of the pin this branch's
+# install recipe is written against, to cover a platform the `sglang` extra cannot run on anyway.
+required-environments = ["sys_platform == 'linux' and platform_machine == 'aarch64'"]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
     "python_full_version < '3.12' and sys_platform != 'linux'",
 ]
+required-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -263,6 +266,13 @@ wheels = [
 name = "av"
 version = "17.0.1"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f0/8c8dca97ae0cf00e8e2a53bb5cb9aca5fd484f585ef3e9b412200aff3ebd/av-17.0.1.tar.gz", hash = "sha256:fbcbd4aa43bca6a8691816283112d1659a27f407bbeb66d1397023691339f5d4", size = 4411938, upload-time = "2026-04-18T17:12:34.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/8b/8de3fd21c4b0b74d44337421abeab0e71462337fb6a28fff888e0c356cbd/av-17.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e6eee84afa48d0e9321047cd3e4facd44b401493f6bdc753e2e1d1e7c9e6d13e", size = 34007351, upload-time = "2026-04-18T17:11:56.116Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fa/aae56f2ff2c204c408641e1120f5ca5ce9c3390cf5362245c6f1158704b5/av-17.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:42d6745d30a410ec9b22aef79a52a7ab5a001eb8f5adfd952946606a30983318", size = 35183754, upload-time = "2026-04-18T17:12:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/5c550231651d6285e6a5c4f6f4a0e67459bfe2b622a7c9352be8cca8c819/av-17.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4744837f4116964280bcc72285e3cdd51361e98a696205aadd924203440ef511", size = 37471077, upload-time = "2026-04-18T17:12:17.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/72/a22a657abc3de652f5b4f46cbbebdf7cba629752112791b81f05d340991d/av-17.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9acd0b6a6e02af2b37f63d97a03ee2c47936d58e82425c3cd075a95245937c59", size = 38397369, upload-time = "2026-04-18T17:12:22.909Z" },
+]
 
 [[package]]
 name = "bigtree"
@@ -2603,13 +2613,13 @@ name = "mlx-lm"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2", marker = "sys_platform != 'linux'" },
+    { name = "jinja2" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "sys_platform != 'linux'" },
-    { name = "protobuf", marker = "sys_platform != 'linux'" },
-    { name = "pyyaml", marker = "sys_platform != 'linux'" },
-    { name = "sentencepiece", marker = "sys_platform != 'linux'" },
-    { name = "transformers", marker = "sys_platform != 'linux'" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/62/f46e1355256a114808517947f8e83ad6be310c7288c551db0fa678f47923/mlx_lm-0.29.1.tar.gz", hash = "sha256:b99180d8f33d33a077b814e550bfb2d8a59ae003d668fd1f4b3fff62a381d34b", size = 232302, upload-time = "2025-12-16T16:58:27.959Z" }
 wheels = [
@@ -2964,7 +2974,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2994,7 +3004,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -3021,9 +3031,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -3034,7 +3044,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },


### PR DESCRIPTION
Closes #161. Branches off `feat/sglang-backend` (#117), where the `sglang` extra and the affected
lock entry live.

## Assessment

Confirmed. On `feat/sglang-backend`, the `av` stanza in `uv.lock` is four lines with nothing to
install:

```toml
[[package]]
name = "av"
version = "17.0.1"
source = { registry = "https://pypi.org/simple" }
```

No `sdist`, no `wheels`. `av` is reachable only under an aarch64-only marker via the `sglang`
extra; the lock is resolved on x86_64 where that marker is false, so uv never explored the branch
and recorded no distribution for it. On ARM, where the marker holds, there is nothing there. As the
issue says, this is not an upstream gap — the aarch64 wheels exist on PyPI.

## Fix

```toml
[tool.uv]
required-environments = ["sys_platform == 'linux' and platform_machine == 'aarch64'"]
```

**`required-environments`, not `environments`.** The issue suggested `environments`, which does fix
the symptom, but it also *restricts* resolution to the enumerated set — anything not listed
(Windows, most obviously) silently loses support. `required-environments` only widens what the lock
must cover, which is the actual requirement here.

**Linux ARM only.** I tried adding `sys_platform == 'darwin' and platform_machine == 'arm64'` for
the Apple-silicon case the issue mentions, and backed it out: sglang publishes no macOS ARM wheels
at 0.5.9, so requiring coverage there forks the resolution back to 0.5.2 and drops
`mlx-lm`/`mlx-metal`. That is 250 lines of lock churn plus a downgrade of the very pin this
branch's Blackwell install recipe is written against — to cover a platform the `sglang` extra can't
run on anyway. The reasoning is recorded in the `pyproject.toml` comment so it isn't re-litigated.

## Effect on the lock

22 insertions, 12 deletions. `av` gains its sdist and four aarch64 wheels
(`cp311-abi3` and `cp314-cp314t`, manylinux and musllinux). The rest is a handful of intra-package
dependency markers simplified as a consequence of the widened resolution space
(`mlx-lm`, `nvidia-cudnn-cu12`, `nvidia-cufft-cu12`, `nvidia-cusolver-cu12`, `nvidia-cusparse-cu12`).
**No package version changes.**

## Testing

- `uv lock --check`: passes.
- `uv sync --dry-run` on x86_64: unchanged apart from the local project re-link, so no regression on
  the platform CI runs.
- `pre-commit run`: clean.

**Needs confirmation on ARM hardware**, which I don't have: `uv sync --extra sglang --frozen` on the
DGX Spark. The defect itself is visible in the file and is fixed there, but the end-to-end install
is worth a look before this is trusted. Note also that this lock was regenerated with uv 0.8.13
while the report came from 0.11.3; the lock revision is unchanged (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAbXzaro3Z6PvX5kkJSH2X
