### PR TITLE
fix: apply SGLang's context ceiling visibly instead of letting it clamp (closes #162)

### DIFF
--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -44,14 +44,14 @@ Gotchas accounted for:
 from __future__ import annotations
 
 import atexit
+import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import torch
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from transformers import GenerationConfig
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,73 @@ _HF_ONLY_KWARGS: frozenset[str] = frozenset(
 #: We probe for both so a version bump in either direction doesn't silently produce empty rows;
 #: if neither key is found we raise loudly (see ``generate_chunk``).
 _SGLANG_OUTPUT_KEYS: tuple[str, ...] = ("output_ids", "token_ids")
+
+#: Positions SGLang's tokenizer-manager validator holds back from the model's context window.
+#: The validator rejects a request outright once ``input_len + max_new_tokens`` reaches the
+#: context length, and the usable ceiling measured against ``sglang==0.5.9`` is
+#: ``context_len - 2`` total positions, not ``context_len - 1``: with a 512-position model and a
+#: 128-token prompt, 382 new tokens is the largest request that comes back at full length, while
+#: 383 and 384 both come back as 382. HF's ``generate``, by contrast, allows the full
+#: ``context_len``. So an SGLang chunk is inherently up to two tokens shorter than the HF chunk
+#: the shared rolling loop asks for, and this backend subtracts that itself rather than letting
+#: the engine clamp silently. The constant is empirical and version-sensitive; if a future SGLang
+#: changes the validator, this is the number to re-measure.
+_SGLANG_CONTEXT_RESERVE = 2
+
+
+def _read_context_length(hf_model_dir: Path | str) -> int | None:
+    """Read ``max_position_embeddings`` from an HF model directory's ``config.json``.
+
+    This is the number SGLang derives its own context length from when it loads the directory, so
+    reading it here lets the adapter apply SGLang's ceiling before the call instead of discovering
+    it as a silent clamp afterwards.
+
+    Returns ``None`` rather than raising if the file is missing, unreadable, or has no
+    ``max_position_embeddings`` — a backend that cannot determine the ceiling falls back to the
+    engine's own ``allow_auto_truncate`` behavior, which is what it did before. Losing the
+    proactive cap is worth strictly less than refusing to construct the backend at all.
+
+    Examples:
+        >>> import json, tempfile
+        >>> from pathlib import Path
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     _ = (Path(d) / "config.json").write_text(json.dumps({"max_position_embeddings": 512}))
+        ...     _read_context_length(d)
+        512
+
+        Missing or malformed configs degrade to ``None``:
+
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     print(_read_context_length(d))
+        None
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     _ = (Path(d) / "config.json").write_text("{not json")
+        ...     print(_read_context_length(d))
+        None
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     _ = (Path(d) / "config.json").write_text(json.dumps({"vocab_size": 40}))
+        ...     print(_read_context_length(d))
+        None
+    """
+    config_fp = Path(hf_model_dir) / "config.json"
+    try:
+        config = json.loads(config_fp.read_text())
+    except (OSError, ValueError) as e:
+        logger.warning(
+            f"Could not read {config_fp} to determine the model's context length "
+            f"({type(e).__name__}: {e}). SGLang's own auto-truncation will apply instead, which "
+            "clamps silently."
+        )
+        return None
+
+    context_len = config.get("max_position_embeddings")
+    if not isinstance(context_len, int):
+        logger.warning(
+            f"{config_fp} has no integer ``max_position_embeddings`` (got {context_len!r}); "
+            "SGLang's own auto-truncation will apply instead, which clamps silently."
+        )
+        return None
+    return context_len
 
 
 def _strip_padding_to_lists(input_ids: torch.Tensor, attention_mask: torch.Tensor | None) -> list[list[int]]:
@@ -204,20 +271,71 @@ class SGLangBackend:
         # this cannot be overridden, and a caller passing ``engine_kwargs={"skip_tokenizer_init":
         # False}`` would otherwise silently break the pipeline.
         self._engine_kwargs["skip_tokenizer_init"] = True
-        # ``allow_auto_truncate`` is also load-bearing in this repo. The rolling loop in
+        # ``allow_auto_truncate`` is a safety net, not the mechanism. The rolling loop in
         # :meth:`MEDS_EIC_AR.model.Model._rolling_generate` sets
         # ``chunk_budget = max_seq_len - prompt_len`` per call — total positions requested =
         # ``max_context_length`` exactly. HF's ``generate`` accepts that boundary (positions
-        # ``0..max_pos-1`` inclusive); SGLang's tokenizer-manager validator rejects it
-        # (``input + max_new >= max_context`` is a hard failure unless ``allow_auto_truncate``
-        # is on). Setting it here matches HF's semantics by silently clamping — otherwise every
-        # first-chunk call in the rolling loop would raise ``ValueError("Requested token count
-        # exceeds...")`` at the boundary. Same non-overridable policy as ``skip_tokenizer_init``
-        # because disabling it would silently re-break cross-backend parity on boundary prompts.
+        # ``0..max_pos-1`` inclusive); SGLang's validator rejects it, and without auto-truncate
+        # every window-saturating call would raise ``ValueError("Requested token count
+        # exceeds...")``. But auto-truncate on its own turns the rejection into a *silent* clamp
+        # that returns up to ``_SGLANG_CONTEXT_RESERVE`` fewer tokens than asked for, which is
+        # not parity with HF however it is described. :meth:`generate_chunk` therefore applies
+        # the ceiling itself, visibly, and this flag only catches a residual mismatch (a SGLang
+        # version whose reserve differs from ours) rather than being the thing that keeps runs
+        # alive. Non-overridable for the same reason as ``skip_tokenizer_init``: disabling it
+        # converts that residual mismatch from a shortfall into a crash mid-run.
         self._engine_kwargs["allow_auto_truncate"] = True
+        self._context_len = _read_context_length(hf_model_dir)
+        # Log the ceiling once at construction rather than per call — the rolling loop calls
+        # ``generate_chunk`` many times with the same shape, and a per-call warning would bury
+        # the run's real output.
+        self._logged_context_clamp = False
         self._engine = sgl_module.Engine(model_path=str(hf_model_dir), **self._engine_kwargs)
         self._is_shutdown = False
         atexit.register(self.shutdown)
+
+    def _cap_max_new_tokens(self, requested: int, prompt_len: int) -> int:
+        """Clamp ``requested`` to what SGLang will actually honor for a ``prompt_len``-token prompt.
+
+        Returns ``requested`` unchanged when the model's context length could not be read (in
+        which case we fall back to the engine's own auto-truncate) or when the request already
+        fits. Otherwise returns the ceiling and logs the shortfall once.
+
+        Raises:
+            ValueError: If the prompt is so long that no new tokens fit under the ceiling. This is
+                reachable from the rolling loop, whose default ``rolling_context_size`` of
+                ``max_seq_len - 1`` leaves only one position for new tokens — one fewer than the
+                reserve needs. Raising beats returning an empty chunk, which the rolling loop
+                would read as "no progress" and spin on forever.
+        """
+        if self._context_len is None:
+            return requested
+
+        allowed = self._context_len - prompt_len - _SGLANG_CONTEXT_RESERVE
+        if allowed >= requested:
+            return requested
+
+        if allowed <= 0:
+            raise ValueError(
+                f"SGLang cannot generate any new tokens for a {prompt_len}-token prompt against a "
+                f"{self._context_len}-position context window: its validator reserves "
+                f"{_SGLANG_CONTEXT_RESERVE} positions, leaving {allowed}. HF's generate accepts "
+                "this prompt, so this is an SGLang-specific ceiling. When generating with the "
+                "rolling loop, set rolling_generation.rolling_context_size to at most "
+                f"{self._context_len - _SGLANG_CONTEXT_RESERVE - 1} so every chunk has room for at "
+                "least one new token."
+            )
+
+        if not self._logged_context_clamp:
+            self._logged_context_clamp = True
+            logger.warning(
+                f"SGLang chunk budget clamped from {requested} to {allowed} new tokens for a "
+                f"{prompt_len}-token prompt: its validator reserves {_SGLANG_CONTEXT_RESERVE} of "
+                f"the model's {self._context_len} positions, where HF's generate would use the "
+                "full window. Generated trajectories will be correspondingly shorter than the HF "
+                "backend's on window-saturating chunks. Logged once per backend instance."
+            )
+        return allowed
 
     def shutdown(self) -> None:
         """Terminate the SGLang scheduler subprocess.
@@ -262,6 +380,12 @@ class SGLangBackend:
         HF-only kwargs (``logits_processor``, ``stopping_criteria``, …) are stripped before
         forwarding so a caller passing a cross-backend kwargs dict doesn't blow up the engine
         subprocess. The stripped kwargs are logged at debug level.
+
+        ``generation_config.max_new_tokens`` is a request, not a guarantee: SGLang reserves
+        ``_SGLANG_CONTEXT_RESERVE`` positions of the model's context window that HF's ``generate``
+        would happily use, so a window-saturating chunk comes back that many tokens shorter. The
+        shortfall is applied here and logged rather than left to the engine to swallow; see
+        :meth:`_cap_max_new_tokens`.
         """
         stripped = {k: v for k, v in kwargs.items() if k in _HF_ONLY_KWARGS}
         if stripped:
@@ -272,6 +396,14 @@ class SGLangBackend:
         forwarded = {k: v for k, v in kwargs.items() if k not in _HF_ONLY_KWARGS}
 
         prompts = _strip_padding_to_lists(input_ids, attention_mask)
+
+        # Apply SGLang's context ceiling ourselves, against the longest prompt in the batch (the
+        # binding one, since ``max_new_tokens`` is shared across the whole call). Doing it here
+        # rather than leaving it to ``allow_auto_truncate`` is what makes the shortfall visible;
+        # see ``_SGLANG_CONTEXT_RESERVE``.
+        max_new_tokens = self._cap_max_new_tokens(
+            generation_config.max_new_tokens, max((len(p) for p in prompts), default=0)
+        )
 
         # Map HF ``GenerationConfig`` → SGLang sampling-params dict. Intentional translations:
         #   - ``do_sample=False`` → ``temperature=0.0`` regardless of the caller's configured
@@ -297,7 +429,7 @@ class SGLangBackend:
         else:
             temperature = 0.0
         sampling_params: dict[str, Any] = {
-            "max_new_tokens": generation_config.max_new_tokens,
+            "max_new_tokens": max_new_tokens,
             "temperature": temperature,
             "stop_token_ids": (
                 [generation_config.eos_token_id] if generation_config.eos_token_id is not None else None
@@ -329,10 +461,10 @@ class SGLangBackend:
             # in the accumulated sequence. Fail loudly instead: the only way a row's length can
             # exceed ``max_new_tokens`` under new-only semantics is if the engine included the
             # prompt.
-            if len(row_tokens) > generation_config.max_new_tokens:
+            if len(row_tokens) > max_new_tokens:
                 raise RuntimeError(
                     f"SGLang output[{i}] returned {len(row_tokens)} tokens but "
-                    f"``max_new_tokens={generation_config.max_new_tokens}`` — the engine appears "
+                    f"``max_new_tokens={max_new_tokens}`` — the engine appears "
                     "to be returning the prompt prefix plus new tokens rather than new-only. "
                     "This breaks the GenerationBackend contract and would silently corrupt the "
                     "rolling loop. Check the installed SGLang version's ``Engine.generate`` "

--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -80,16 +80,32 @@ _HF_ONLY_KWARGS: frozenset[str] = frozenset(
 #: if neither key is found we raise loudly (see ``generate_chunk``).
 _SGLANG_OUTPUT_KEYS: tuple[str, ...] = ("output_ids", "token_ids")
 
-#: Positions SGLang's tokenizer-manager validator holds back from the model's context window.
-#: The validator rejects a request outright once ``input_len + max_new_tokens`` reaches the
-#: context length, and the usable ceiling measured against ``sglang==0.5.9`` is
-#: ``context_len - 2`` total positions, not ``context_len - 1``: with a 512-position model and a
-#: 128-token prompt, 382 new tokens is the largest request that comes back at full length, while
-#: 383 and 384 both come back as 382. HF's ``generate``, by contrast, allows the full
-#: ``context_len``. So an SGLang chunk is inherently up to two tokens shorter than the HF chunk
-#: the shared rolling loop asks for, and this backend subtracts that itself rather than letting
-#: the engine clamp silently. The constant is empirical and version-sensitive; if a future SGLang
-#: changes the validator, this is the number to re-measure.
+#: Positions SGLang holds back from the model's context window, on top of the prompt.
+#:
+#: Two layers are involved and only the second costs tokens. The tokenizer manager checks
+#: ``len(input) + max_new_tokens >= context_len`` and either raises or, under
+#: ``allow_auto_truncate``, clamps to ``context_len - len(input)`` — a no-op at exactly the
+#: boundary. The *scheduler* is what actually trims, in ``init_req_max_new_tokens``::
+#:
+#:     max_req_len    = min(context_len - 1, max_token_pool_size - 1)   # tp_worker
+#:     max_new_tokens = min(requested, max_req_len - len(input) - 1)    # scheduler
+#:
+#: which is ``context_len - len(input) - 2`` whenever the context length is the binding term.
+#: That ``min`` is unconditional: no warning, and not gated on ``allow_auto_truncate``. HF's
+#: ``generate``, by contrast, will fill the window exactly. Matches the measurement it was
+#: derived from — on a 512-position model with a 128-token prompt, 382 new tokens is the largest
+#: request honored in full, while 383 and 384 both come back as 382.
+#:
+#: **Two is a floor, not a guarantee.** When the KV pool is the binding term instead — a large
+#: model, or a small ``mem_fraction_static`` — ``max_req_len`` is smaller than ``context_len - 1``
+#: and the shortfall grows. Capping by this constant keeps the common case honest; the residual is
+#: what ``allow_auto_truncate`` is left on to absorb.
+#:
+#: The subtraction also goes negative: at ``len(input) == context_len - 1`` the scheduler's cap is
+#: ``-1``, and ``Req.check_finished`` stops on ``len(output_ids) >= max_new_tokens``, which holds
+#: at zero output tokens. The request completes having generated nothing — which is why
+#: :meth:`SGLangBackend._cap_max_new_tokens` raises rather than letting the rolling loop receive an
+#: empty chunk it would spin on.
 _SGLANG_CONTEXT_RESERVE = 2
 
 
@@ -271,19 +287,18 @@ class SGLangBackend:
         # this cannot be overridden, and a caller passing ``engine_kwargs={"skip_tokenizer_init":
         # False}`` would otherwise silently break the pipeline.
         self._engine_kwargs["skip_tokenizer_init"] = True
-        # ``allow_auto_truncate`` is a safety net, not the mechanism. The rolling loop in
+        # ``allow_auto_truncate`` keeps window-saturating requests from being *rejected*; it is
+        # not what costs tokens. The rolling loop in
         # :meth:`MEDS_EIC_AR.model.Model._rolling_generate` sets
         # ``chunk_budget = max_seq_len - prompt_len`` per call — total positions requested =
         # ``max_context_length`` exactly. HF's ``generate`` accepts that boundary (positions
-        # ``0..max_pos-1`` inclusive); SGLang's validator rejects it, and without auto-truncate
-        # every window-saturating call would raise ``ValueError("Requested token count
-        # exceeds...")``. But auto-truncate on its own turns the rejection into a *silent* clamp
-        # that returns up to ``_SGLANG_CONTEXT_RESERVE`` fewer tokens than asked for, which is
-        # not parity with HF however it is described. :meth:`generate_chunk` therefore applies
-        # the ceiling itself, visibly, and this flag only catches a residual mismatch (a SGLang
-        # version whose reserve differs from ours) rather than being the thing that keeps runs
-        # alive. Non-overridable for the same reason as ``skip_tokenizer_init``: disabling it
-        # converts that residual mismatch from a shortfall into a crash mid-run.
+        # ``0..max_pos-1`` inclusive); SGLang's tokenizer manager raises on it unless this flag is
+        # set. The token loss happens further in, in the scheduler, and happens either way — see
+        # ``_SGLANG_CONTEXT_RESERVE``. So this flag is what keeps boundary requests alive, and
+        # :meth:`generate_chunk` is what makes the resulting shortfall visible instead of leaving
+        # it to be discovered in the output shape. Non-overridable for the same reason as
+        # ``skip_tokenizer_init``: turning it off converts every window-saturating chunk from a
+        # shortfall into a crash mid-run.
         self._engine_kwargs["allow_auto_truncate"] = True
         self._context_len = _read_context_length(hf_model_dir)
         # Log the ceiling once at construction rather than per call — the rolling loop calls
@@ -318,10 +333,12 @@ class SGLangBackend:
         if allowed <= 0:
             raise ValueError(
                 f"SGLang cannot generate any new tokens for a {prompt_len}-token prompt against a "
-                f"{self._context_len}-position context window: its validator reserves "
-                f"{_SGLANG_CONTEXT_RESERVE} positions, leaving {allowed}. HF's generate accepts "
-                "this prompt, so this is an SGLang-specific ceiling. When generating with the "
-                "rolling loop, set rolling_generation.rolling_context_size to at most "
+                f"{self._context_len}-position context window: its scheduler caps max_new_tokens "
+                f"at max_req_len - len(input) - 1, which holds back {_SGLANG_CONTEXT_RESERVE} "
+                f"positions and leaves {allowed} here. At or past this point SGLang returns an "
+                "empty completion rather than an error, which the rolling loop would read as no "
+                "progress and spin on. HF's generate accepts this prompt, so the ceiling is "
+                "SGLang-specific. Set rolling_generation.rolling_context_size to at most "
                 f"{self._context_len - _SGLANG_CONTEXT_RESERVE - 1} so every chunk has room for at "
                 "least one new token."
             )
@@ -330,10 +347,11 @@ class SGLangBackend:
             self._logged_context_clamp = True
             logger.warning(
                 f"SGLang chunk budget clamped from {requested} to {allowed} new tokens for a "
-                f"{prompt_len}-token prompt: its validator reserves {_SGLANG_CONTEXT_RESERVE} of "
-                f"the model's {self._context_len} positions, where HF's generate would use the "
-                "full window. Generated trajectories will be correspondingly shorter than the HF "
-                "backend's on window-saturating chunks. Logged once per backend instance."
+                f"{prompt_len}-token prompt: its scheduler holds back "
+                f"{_SGLANG_CONTEXT_RESERVE} of the model's {self._context_len} positions, where "
+                "HF's generate would use the full window. Generated trajectories will be "
+                "correspondingly shorter than the HF backend's on window-saturating chunks. "
+                "Logged once per backend instance."
             )
         return allowed
 

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -17,14 +17,22 @@ What's deliberately NOT tested here:
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import torch
 from transformers import GenerationConfig
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 from MEDS_EIC_AR.model.backends import GenerationBackend, SGLangBackend
-from MEDS_EIC_AR.model.backends.sglang import _pad_right_to_tensor, _strip_padding_to_lists
+from MEDS_EIC_AR.model.backends.sglang import (
+    _SGLANG_CONTEXT_RESERVE,
+    _pad_right_to_tensor,
+    _strip_padding_to_lists,
+)
 
 
 class _FakeEngine:
@@ -84,6 +92,30 @@ def _make_backend() -> tuple[SGLangBackend, _FakeSGLModule]:
     return backend, fake
 
 
+def _make_backend_with_context(tmp_path: Path, context_len: int) -> tuple[SGLangBackend, _FakeSGLModule]:
+    """Build a backend over an HF directory whose ``config.json`` declares ``context_len`` positions.
+
+    The plain :func:`_make_backend` points at a path with no ``config.json``, so the backend cannot
+    determine a ceiling and leaves budgets alone — which is what keeps the older tests here
+    unaffected by the context-window clamp. Tests that exercise the clamp need a readable config.
+    """
+    (tmp_path / "config.json").write_text(json.dumps({"max_position_embeddings": context_len}))
+    fake = _FakeSGLModule()
+    backend = SGLangBackend(tmp_path, sgl_module=fake)
+    return backend, fake
+
+
+def _one_row_call(backend: SGLangBackend, fake: _FakeSGLModule, prompt_len: int, max_new_tokens: int):
+    """Run one ``generate_chunk`` with a ``prompt_len``-token prompt; return the sampling params sent."""
+    input_ids = torch.arange(1, prompt_len + 1, dtype=torch.long).unsqueeze(0)
+    fake.last_engine.set_next_outputs([{"output_ids": [7]}])
+    cfg = GenerationConfig(max_new_tokens=max_new_tokens, do_sample=False, pad_token_id=0, eos_token_id=99)
+    backend.generate_chunk(
+        input_ids, attention_mask=torch.ones_like(input_ids, dtype=torch.bool), generation_config=cfg
+    )
+    return fake.last_engine.generate_calls[-1]["sampling_params"]
+
+
 # ---------------------------------------------------------------------------
 # Protocol / structural contract
 # ---------------------------------------------------------------------------
@@ -135,8 +167,11 @@ def test_engine_receives_allow_auto_truncate_by_default():
     prompt_len`` on each chunk, so ``input_len + max_new_tokens == max_context_length`` on
     boundary prompts. HF accepts this (positions are inclusive), SGLang rejects it by default
     (``input + max_new >= max_context`` is a hard failure in the tokenizer-manager validator).
-    ``allow_auto_truncate=True`` silently clamps to match HF, which is what cross-backend
-    parity requires. Losing this would break the first chunk of every rolling run.
+
+    The backend now applies that ceiling itself, visibly, so this flag is a safety net rather
+    than the mechanism: it catches a residual mismatch (a SGLang whose reserve differs from the
+    one we subtract) as a shortfall instead of a crash mid-run. It is *not* parity with HF —
+    the clamp costs real tokens, which is why the clamp is logged where it happens.
     """
     _, fake = _make_backend()
     assert fake.last_engine is not None
@@ -146,9 +181,10 @@ def test_engine_receives_allow_auto_truncate_by_default():
 def test_allow_auto_truncate_cannot_be_overridden_by_caller():
     """A caller passing ``allow_auto_truncate=False`` in ``engine_kwargs`` must be ignored.
 
-    Same reasoning as ``skip_tokenizer_init`` — disabling it silently re-breaks every rolling
-    run's first chunk at the HF/SGLang boundary-semantics mismatch. The class docstring
-    promises this invariant is non-overridable.
+    Same reasoning as ``skip_tokenizer_init``: with it off, any residual mismatch between the
+    reserve this backend subtracts and the one the installed SGLang enforces turns from a
+    shortfall into a hard failure partway through a run. The class docstring promises this
+    invariant is non-overridable.
     """
     fake = _FakeSGLModule()
     backend = SGLangBackend(
@@ -487,3 +523,113 @@ def test_missing_sglang_raises_clear_error(monkeypatch):
 
     with pytest.raises(ImportError, match="pip install MEDS_EIC_AR\\[sglang\\]"):
         SGLangBackend("/tmp/ignored")
+
+
+# ---------------------------------------------------------------------------
+# Context-window ceiling
+# ---------------------------------------------------------------------------
+
+
+def test_budget_below_the_ceiling_is_passed_through_unchanged(tmp_path: Path):
+    """A request that comfortably fits must reach the engine exactly as asked.
+
+    Guards against a clamp that fires unconditionally and silently shortens every chunk, which would be a
+    worse bug than the one being fixed.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=512)
+    sp = _one_row_call(backend, fake, prompt_len=128, max_new_tokens=256)
+    assert sp["max_new_tokens"] == 256
+
+
+def test_budget_at_the_ceiling_is_passed_through_unchanged(tmp_path: Path):
+    """The largest request SGLang honors in full must not be clamped.
+
+    ``context_len - prompt_len - reserve`` is the boundary; one token below it and at it are the
+    two cases an off-by-one in the cap would get wrong.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=512)
+    ceiling = 512 - 128 - _SGLANG_CONTEXT_RESERVE
+    assert _one_row_call(backend, fake, prompt_len=128, max_new_tokens=ceiling - 1)["max_new_tokens"] == (
+        ceiling - 1
+    )
+    assert _one_row_call(backend, fake, prompt_len=128, max_new_tokens=ceiling)["max_new_tokens"] == ceiling
+
+
+def test_budget_over_the_ceiling_is_clamped_and_logged(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    """A window-saturating request must be cut to the ceiling *by us*, visibly.
+
+    This is the reported defect: the shared rolling loop asks for ``max_seq_len - prompt_len``,
+    i.e. the full window, and SGLang's ``allow_auto_truncate`` used to swallow the excess without
+    a word. The clamp is now applied here and announced.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=512)
+    ceiling = 512 - 128 - _SGLANG_CONTEXT_RESERVE
+
+    with caplog.at_level("WARNING"):
+        sp = _one_row_call(backend, fake, prompt_len=128, max_new_tokens=384)
+
+    assert sp["max_new_tokens"] == ceiling
+    assert any("clamped from 384" in r.getMessage() for r in caplog.records), (
+        f"Expected a warning naming the clamp; got {[r.getMessage() for r in caplog.records]}."
+    )
+
+
+def test_clamp_warning_is_logged_only_once_per_backend(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    """The rolling loop calls ``generate_chunk`` once per chunk, all with the same saturating shape.
+
+    Warning every time would bury the run's real output under hundreds of identical lines, so the message is
+    emitted once per backend instance.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=512)
+    with caplog.at_level("WARNING"):
+        for _ in range(5):
+            _one_row_call(backend, fake, prompt_len=128, max_new_tokens=384)
+
+    clamp_warnings = [r for r in caplog.records if "clamped from" in r.getMessage()]
+    assert len(clamp_warnings) == 1, f"Expected exactly one clamp warning, got {len(clamp_warnings)}."
+
+
+def test_prompt_leaving_no_room_raises_rather_than_returning_an_empty_chunk(tmp_path: Path):
+    """A prompt at ``context_len - 1`` must raise, not return zero tokens.
+
+    This is exactly what the rolling loop's default ``rolling_context_size = max_seq_len - 1``
+    produces once the window saturates: a prompt one position short of the window, leaving room for
+    one new token where SGLang needs the reserve to fit too. ``_rolling_generate`` advances by the
+    number of tokens a chunk returns and loops until its budget is met, so an empty chunk would
+    make it spin forever. The error names the knob to change.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=512)
+    with pytest.raises(ValueError, match="rolling_context_size"):
+        _one_row_call(backend, fake, prompt_len=511, max_new_tokens=1)
+
+
+def test_ceiling_uses_the_longest_prompt_in_the_batch(tmp_path: Path):
+    """``max_new_tokens`` is shared across the batch, so the longest prompt is the binding one.
+
+    Rolling chunks are ragged after post-EOS padding is stripped: rows that finished earlier come
+    through shorter. Sizing the budget off a short row would let the longest row exceed the window.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=64)
+    # Row 0 is 8 real tokens, row 1 is 40 — left-padded to a common width, as the rolling loop emits.
+    input_ids = torch.arange(1, 41, dtype=torch.long).repeat(2, 1)
+    attention_mask = torch.ones_like(input_ids, dtype=torch.bool)
+    attention_mask[0, :32] = False
+
+    fake.last_engine.set_next_outputs([{"output_ids": [7]}, {"output_ids": [7]}])
+    cfg = GenerationConfig(max_new_tokens=40, do_sample=False, pad_token_id=0, eos_token_id=99)
+    backend.generate_chunk(input_ids, attention_mask=attention_mask, generation_config=cfg)
+
+    sp = fake.last_engine.generate_calls[-1]["sampling_params"]
+    assert sp["max_new_tokens"] == 64 - 40 - _SGLANG_CONTEXT_RESERVE
+
+
+def test_unreadable_config_leaves_the_budget_alone(tmp_path: Path):
+    """With no readable ``config.json`` the ceiling is unknown, so the request must pass through.
+
+    Falling back to the engine's own ``allow_auto_truncate`` is worse than capping proactively, but
+    much better than refusing to construct the backend or guessing a context length.
+    """
+    fake = _FakeSGLModule()
+    backend = SGLangBackend(tmp_path, sgl_module=fake)  # empty dir: no config.json
+    assert backend._context_len is None
+    assert _one_row_call(backend, fake, prompt_len=128, max_new_tokens=100_000)["max_new_tokens"] == 100_000


### PR DESCRIPTION
Closes #162. Branches off `feat/sglang-backend` (#117).

## Assessment

The report is right, and the docstring it quotes was making a claim the code doesn't support. I'd
add one thing the issue doesn't cover, which changes what the right fix is.

**The rolling path doesn't just lose two tokens — it can hang.** `_rolling_generate` advances by
`new_tokens.size(1)` and loops `while n_generated < max_new_tokens`. Its default
`rolling_context_size` is `max_seq_len - 1`, so once the window saturates every chunk has
`prompt_len = max_seq_len - 1` and `chunk_budget = 1` — two positions past SGLang's ceiling, with
only one to give back. A clamp that lands on zero returns an empty chunk, the loop makes no
progress, and it spins forever. Silent shortening is the benign case.

## Which of the three suggested fixes

Option 1 (cap in the backend, log it), not option 2. Costing HF two tokens on every chunk to match
an SGLang validator quirk buys symmetry at the price of correctness on the backend that was already
right. And capping *before* the call is what makes the zero-budget case detectable at all — the
engine clamping after the fact can only hand back an empty chunk.

## What this does

`SGLangBackend` reads `max_position_embeddings` from the exported HF directory's `config.json` — the
same number SGLang derives its context length from — and subtracts `_SGLANG_CONTEXT_RESERVE = 2`
before the call:

| case | behavior |
| --- | --- |
| request fits under the ceiling | passed through untouched |
| request over the ceiling | cut to the ceiling, warned **once per backend instance** |
| prompt leaves no room | `ValueError` naming the knob to change |
| `config.json` unreadable | budget untouched; falls back to the engine's auto-truncate, as before |

Log-once matters because the rolling loop calls `generate_chunk` once per chunk with the same
saturating shape — warning every time would bury the run's real output under hundreds of identical
lines.

The ceiling is computed against the **longest** prompt in the batch, since `max_new_tokens` is
shared across the call and rolling chunks are ragged once post-EOS padding is stripped.

`allow_auto_truncate` stays on, but demoted from mechanism to safety net: it now only catches a
residual mismatch between the reserve we subtract and the one an installed SGLang enforces, as a
shortfall rather than a mid-run crash. The comments and test docstrings that described it as
matching HF are corrected — per the issue's option 3, which is folded in rather than chosen instead.

## Behavior change worth flagging

**Rolling generation on SGLang now needs `rolling_generation.rolling_context_size <= max_seq_len - 3`**
and raises with that message otherwise. That is a new hard failure where there was previously a hang
or a silently corrupted trajectory, so I think it's the right trade — but it's a real change, not
just a diagnostic.

The nicer end state is for `GenerationBackend` to declare its context reserve and for
`_rolling_generate` to size `ctx_size` around it, so the default config just works on every backend.
That touches the protocol and the shared loop on `main`, so I've left it out of this PR; happy to
file it as a follow-up if you want it.

## Testing

- Seven new tests against the existing fake engine: pass-through below and at the ceiling, the clamp
  and its warning, log-once, the no-room raise, longest-prompt sizing, and the unreadable-config
  fallback. Plus doctests on the config reader.
- `uv run pytest --ignore=tests/grammar`: 110 passed, 4 skipped.
- `pre-commit run`: clean.

**Not verified on real hardware — this machine has no GPU.** Worth confirming on the DGX Spark that
a rolling run with `rolling_context_size = max_seq_len - 3` completes, and that the default one
raises the intended error rather than hanging.

The constant itself no longer needs re-measuring — see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAbXzaro3Z6PvX5kkJSH2X

---

## Follow-up: traced through the sglang source

Rather than leave `_SGLANG_CONTEXT_RESERVE = 2` as a measured constant, I read `sglang` v0.5.9. The
2 is exact and derivable, and my original attribution was wrong — pushed as fa02e7e (comments only,
no behavior change).

It is **not** the tokenizer-manager validator, and **not** `allow_auto_truncate`. That layer checks
`len(input) + max_new_tokens >= context_len` and, under auto-truncate, clamps to
`context_len - len(input)` — a no-op at exactly the boundary. (Its `num_reserved_tokens` addend is 0
unless Eagle speculative decoding is on.) The file even flags the split itself:
`# FIXME: unify the length validation logic with the one in the scheduler.`

The tokens go in the **scheduler**:

```python
# tp_worker.py
self.max_req_len = min(self.model_config.context_len - 1, self.model_runner.max_token_pool_size - 1)

# scheduler.py, init_req_max_new_tokens
req.sampling_params.max_new_tokens = min(
    req.sampling_params.max_new_tokens if ... is not None else 1 << 30,
    self.max_req_len - len(req.origin_input_ids) - 1,
)
```

`(context_len - 1) - len(input) - 1` = **`context_len - len(input) - 2`**, matching the reported
table exactly. That `min` is unconditional: no warning, not gated on `allow_auto_truncate`. So
`allow_auto_truncate` only decides whether a boundary request is *rejected*; it never had anything
to do with the two missing tokens.

Two things this changes:

**2 is a floor, not a guarantee.** `max_req_len` takes the `min` with `max_token_pool_size - 1`. When
the KV pool binds instead of the context length — a large model, or a small `mem_fraction_static` —
the shortfall is larger than 2. Capping by the constant keeps the common case honest; the residual
is what `allow_auto_truncate` is left on to absorb. Worth knowing alongside the
`mem_fraction_static` change in #169.

**The empty-chunk hang is confirmed from source, not inferred.** At `len(input) == context_len - 1` —
exactly what the rolling loop's default `rolling_context_size` produces once the window saturates —
the scheduler's cap evaluates to `-1`. `Req.check_finished` stops on
`len(output_ids) >= max_new_tokens`, which holds at zero output tokens, so the request completes
having generated nothing. `n_generated += 0`, and the loop spins. That is the case this PR raises on.
