### PR TITLE
fix: make SGLang's head-dim floor and memory reservation safe by default (closes #163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,18 @@ Three further runtime requirements on this hardware:
 - **Put `.venv/bin` on `PATH`.** SGLang JIT-compiles some kernels at engine startup and shells out to
     `ninja`, which is installed as a venv console script; without it the engine dies with
     `FileNotFoundError: [Errno 2] No such file or directory: 'ninja'`.
-- Use `attention_head_dim >= 64`, or pass `+backend.engine_kwargs.attention_backend=triton`. SGLang's
+- Use `attention_head_dim >= 64`, or pass `backend.engine_kwargs.attention_backend=triton`. SGLang's
     default FlashInfer attention backend rejects small head dims with
     `FlashInfer Internal Error: Invalid configuration ... BatchPrefillWithRaggedKVCacheDispatched`.
     The failure kills the scheduler subprocess and surfaces in the parent as exit `-9`, which looks
-    like an OOM rather than a shape error. See
-    [#163](https://github.com/mmcdermott/MEDS_EIC_AR/issues/163).
+    like an OOM rather than a shape error. `SGLangBackend` now refuses to start in that configuration
+    with an error naming both remedies, and `sglang_demo.yaml` selects `triton` so the small models it
+    targets work as-is.
 
-Note also that `sglang_demo.yaml` sets `mem_fraction_static: 0.85`, a fraction of *total* memory. DGX
-Spark shares one 128 GB pool between CPU and GPU, so that reserves ~109 GB and leaves the host close to
-the OOM killer; `0.2`–`0.4` is ample for small models.
+`mem_fraction_static` is a fraction of *total* device memory, reserved up front for the KV cache.
+`sglang.yaml` keeps `0.85`, which suits a dedicated GPU. On a unified-memory host it does not: DGX Spark
+shares one 128 GB pool between CPU and GPU, so `0.85` reserves ~109 GB and leaves the host close to the
+OOM killer. `sglang_demo.yaml` uses `0.3`; lower `sglang.yaml` to `0.2`–`0.4` as well when running there.
 
 > [!NOTE]
 > `uv sync --frozen` currently fails on aarch64 hosts: `uv.lock`'s `av` entry records no wheel or sdist,

--- a/src/MEDS_EIC_AR/configs/backend/sglang.yaml
+++ b/src/MEDS_EIC_AR/configs/backend/sglang.yaml
@@ -31,3 +31,8 @@ engine_kwargs:
   mem_fraction_static: 0.85
   max_running_requests: 256
   tp_size: 1
+  # ``null`` means "let SGLang choose", which is FlashInfer. The key is present rather than
+  # omitted so it can be overridden as ``backend.engine_kwargs.attention_backend=triton`` without
+  # Hydra's ``+`` append syntax. ``SGLangBackend`` treats an explicit ``null`` the same as an
+  # absent key: it is not a choice, so the head-dim floor check still applies.
+  attention_backend: null

--- a/src/MEDS_EIC_AR/configs/backend/sglang.yaml
+++ b/src/MEDS_EIC_AR/configs/backend/sglang.yaml
@@ -11,8 +11,15 @@ _target_: MEDS_EIC_AR.model.backends.build_sglang_backend
 
 # Kwargs forwarded verbatim to ``sglang.Engine(...)``. Override from the CLI with
 # ``backend.engine_kwargs.<key>=<val>``.
-#  - ``mem_fraction_static``: fraction of GPU memory SGLang keeps for KV cache. 0.85 leaves
-#    ~15% free for the Lightning backbone copy and other GPU consumers.
+#  - ``mem_fraction_static``: fraction of *total* device memory SGLang reserves up front for the
+#    KV cache. 0.85 leaves ~15% free for the Lightning backbone copy and other GPU consumers,
+#    which is right for a dedicated GPU. **Lower it substantially on unified-memory hosts**,
+#    where CPU and GPU share one pool: on a DGX Spark's 128 GB, 0.85 reserves ~109 GB and leaves
+#    the host a couple of GB, which invites the OOM killer. 0.2–0.4 is ample for a small model.
+#  - ``attention_backend``: left unset, so SGLang picks FlashInfer. That backend cannot dispatch
+#    attention head dimensions below 64; ``SGLangBackend`` refuses to start rather than let it
+#    abort the scheduler subprocess in a way that looks like an OOM. Set ``triton`` for narrow
+#    models.
 #  - ``max_running_requests``: cap on concurrent in-flight requests. 256 is plenty for
 #    typical batch-generation workloads; raise if you're saturating it.
 #  - ``tp_size``: tensor-parallel degree. 1 for single-GPU; set higher for multi-GPU

--- a/src/MEDS_EIC_AR/configs/backend/sglang_demo.yaml
+++ b/src/MEDS_EIC_AR/configs/backend/sglang_demo.yaml
@@ -8,13 +8,26 @@
 #    capture trades per-step decode speed for fast cold-start. Flip to ``false`` (or
 #    switch to ``backend=sglang``) for batched-inference-over-a-full-dataset workloads.
 #  - ``max_running_requests: 8`` — test scale. Production ``sglang.yaml`` uses 256.
+#  - ``attention_backend: triton`` — SGLang's default FlashInfer backend cannot dispatch
+#    attention head dimensions below 64, and the models this config exists for are small enough
+#    to sit under that floor (the grammar fixture's default is 32). Triton has no such floor, so
+#    naming it here is what lets the gated integration test run against the fixture's own model
+#    shape instead of requiring a wider one. ``SGLangBackend`` refuses to start on a too-small
+#    head dim when this is left unset, since FlashInfer's failure mode there is a scheduler abort
+#    that looks like an OOM.
+#  - ``mem_fraction_static: 0.3`` — this is a fraction of *total* device memory, and it is
+#    reserved up front for the KV cache. Production's 0.85 is sized for a dedicated GPU; on a
+#    unified-memory host where CPU and GPU share one pool (DGX Spark's 128 GB, say) that reserves
+#    ~109 GB and leaves the host a couple of GB, which invites the OOM killer. 0.3 is ample for
+#    the small models this config targets and is safe on both kinds of host.
 #
 # Activation: ``MEICAR_generate_trajectories backend=sglang_demo ...`` (or referenced via
 # ``_demo_generate_trajectories.yaml`` defaults when that CLI runs).
 _target_: MEDS_EIC_AR.model.backends.build_sglang_backend
 
 engine_kwargs:
-  mem_fraction_static: 0.85
+  mem_fraction_static: 0.3
   max_running_requests: 8
   tp_size: 1
   disable_cuda_graph: true
+  attention_backend: triton

--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -93,59 +93,127 @@ _SGLANG_OUTPUT_KEYS: tuple[str, ...] = ("output_ids", "token_ids")
 _SGLANG_CONTEXT_RESERVE = 2
 
 
-def _read_context_length(hf_model_dir: Path | str) -> int | None:
-    """Read ``max_position_embeddings`` from an HF model directory's ``config.json``.
+#: Smallest attention head dimension SGLang's default FlashInfer attention backend can dispatch.
+#: Below this it aborts the scheduler subprocess with ``FlashInfer Internal Error: Invalid
+#: configuration``, which reaches the parent as SIGQUIT / exit ``-9`` — indistinguishable at a
+#: glance from an out-of-memory kill, and so a genuinely expensive thing to debug. Measured against
+#: ``sglang==0.5.9``: ``head_dim=32`` aborts, ``head_dim=64`` works. The ``triton`` attention
+#: backend has no such floor.
+_FLASHINFER_MIN_HEAD_DIM = 64
 
-    This is the number SGLang derives its own context length from when it loads the directory, so
-    reading it here lets the adapter apply SGLang's ceiling before the call instead of discovering
-    it as a silent clamp afterwards.
 
-    Returns ``None`` rather than raising if the file is missing, unreadable, or has no
-    ``max_position_embeddings`` — a backend that cannot determine the ceiling falls back to the
-    engine's own ``allow_auto_truncate`` behavior, which is what it did before. Losing the
-    proactive cap is worth strictly less than refusing to construct the backend at all.
+def _read_hf_config(hf_model_dir: Path | str) -> dict:
+    """Parse an HF model directory's ``config.json``, or return ``{}`` if it can't be read.
+
+    Degrading to an empty dict rather than raising is deliberate: every use of this config is a
+    pre-flight check that improves diagnostics, and none of them is worth refusing to construct
+    the backend over. A missing config costs the checks, not the run.
 
     Examples:
         >>> import json, tempfile
         >>> from pathlib import Path
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = (Path(d) / "config.json").write_text(json.dumps({"max_position_embeddings": 512}))
-        ...     _read_context_length(d)
-        512
+        ...     _ = (Path(d) / "config.json").write_text(json.dumps({"head_dim": 64}))
+        ...     _read_hf_config(d)
+        {'head_dim': 64}
 
-        Missing or malformed configs degrade to ``None``:
+        Missing and malformed configs both degrade to ``{}``:
 
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     print(_read_context_length(d))
-        None
+        ...     _read_hf_config(d)
+        {}
         >>> with tempfile.TemporaryDirectory() as d:
         ...     _ = (Path(d) / "config.json").write_text("{not json")
-        ...     print(_read_context_length(d))
-        None
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = (Path(d) / "config.json").write_text(json.dumps({"vocab_size": 40}))
-        ...     print(_read_context_length(d))
-        None
+        ...     _read_hf_config(d)
+        {}
     """
     config_fp = Path(hf_model_dir) / "config.json"
     try:
         config = json.loads(config_fp.read_text())
     except (OSError, ValueError) as e:
         logger.warning(
-            f"Could not read {config_fp} to determine the model's context length "
-            f"({type(e).__name__}: {e}). SGLang's own auto-truncation will apply instead, which "
-            "clamps silently."
+            f"Could not read {config_fp} ({type(e).__name__}: {e}). The SGLang backend's "
+            "pre-flight checks on context length and attention head dimension will be skipped."
         )
-        return None
+        return {}
+    return config if isinstance(config, dict) else {}
 
-    context_len = config.get("max_position_embeddings")
-    if not isinstance(context_len, int):
-        logger.warning(
-            f"{config_fp} has no integer ``max_position_embeddings`` (got {context_len!r}); "
-            "SGLang's own auto-truncation will apply instead, which clamps silently."
-        )
+
+def _config_int(config: dict, key: str) -> int | None:
+    """Pull an integer field out of a parsed HF config, or ``None`` if it isn't there.
+
+    Examples:
+        >>> _config_int({"head_dim": 64}, "head_dim")
+        64
+        >>> print(_config_int({}, "head_dim"))
+        None
+        >>> print(_config_int({"head_dim": None}, "head_dim"))
+        None
+        >>> print(_config_int({"head_dim": "64"}, "head_dim"))
+        None
+
+        ``bool`` is a subclass of ``int`` but never a valid answer here:
+
+        >>> print(_config_int({"head_dim": True}, "head_dim"))
+        None
+    """
+    value = config.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
         return None
-    return context_len
+    return value
+
+
+def _check_head_dim_against_attention_backend(head_dim: int | None, engine_kwargs: dict) -> None:
+    """Refuse to start SGLang on a default attention backend that cannot dispatch this head dim.
+
+    SGLang defaults to FlashInfer, which aborts on ``head_dim`` below
+    :data:`_FLASHINFER_MIN_HEAD_DIM`. The abort kills the scheduler subprocess and surfaces in the
+    parent as SIGQUIT / exit ``-9``, so what is really a shape constraint reads as an
+    out-of-memory kill — the single most misleading failure this backend can produce. Catching it
+    here costs nothing and names both remedies.
+
+    The check only fires when ``attention_backend`` is left unset, i.e. when *we* are the ones
+    letting SGLang pick FlashInfer. A caller who names a backend explicitly has made a choice and
+    is trusted with it, which also means this cannot wrongly block a future FlashInfer that lifts
+    the floor.
+
+    Args:
+        head_dim: The model's attention head dimension, or ``None`` if it could not be read (in
+            which case there is nothing to check).
+        engine_kwargs: The kwargs about to be passed to ``sglang.Engine``.
+
+    Raises:
+        ValueError: If the head dimension is below the FlashInfer floor and no attention backend
+            was named.
+
+    Examples:
+        Fine: head dim at or above the floor, or unknown, or a backend named explicitly.
+
+        >>> _check_head_dim_against_attention_backend(64, {})
+        >>> _check_head_dim_against_attention_backend(None, {})
+        >>> _check_head_dim_against_attention_backend(32, {"attention_backend": "triton"})
+
+        Refused: below the floor with the backend left to SGLang's default.
+
+        >>> _check_head_dim_against_attention_backend(32, {})
+        Traceback (most recent call last):
+            ...
+        ValueError: SGLang's default FlashInfer attention backend cannot dispatch
+        attention_head_dim=32 ...
+    """
+    if head_dim is None or head_dim >= _FLASHINFER_MIN_HEAD_DIM:
+        return
+    if engine_kwargs.get("attention_backend") is not None:
+        return
+    raise ValueError(
+        f"SGLang's default FlashInfer attention backend cannot dispatch attention_head_dim="
+        f"{head_dim} (its floor is {_FLASHINFER_MIN_HEAD_DIM}). It would abort the scheduler "
+        "subprocess with 'FlashInfer Internal Error: Invalid configuration', which reaches this "
+        "process as SIGQUIT / exit -9 and looks like an out-of-memory kill rather than a shape "
+        "error. Either train with lightning_module.model.gpt_kwargs.attention_head_dim>="
+        f"{_FLASHINFER_MIN_HEAD_DIM}, or select an attention backend that has no such floor with "
+        "backend.engine_kwargs.attention_backend=triton."
+    )
 
 
 def _strip_padding_to_lists(input_ids: torch.Tensor, attention_mask: torch.Tensor | None) -> list[list[int]]:
@@ -285,7 +353,14 @@ class SGLangBackend:
         # alive. Non-overridable for the same reason as ``skip_tokenizer_init``: disabling it
         # converts that residual mismatch from a shortfall into a crash mid-run.
         self._engine_kwargs["allow_auto_truncate"] = True
-        self._context_len = _read_context_length(hf_model_dir)
+        hf_config = _read_hf_config(hf_model_dir)
+        self._context_len = _config_int(hf_config, "max_position_embeddings")
+        if self._context_len is None:
+            logger.warning(
+                f"No integer ``max_position_embeddings`` in {Path(hf_model_dir) / 'config.json'}; "
+                "SGLang's own auto-truncation will apply instead, which clamps silently."
+            )
+        _check_head_dim_against_attention_backend(_config_int(hf_config, "head_dim"), self._engine_kwargs)
         # Log the ceiling once at construction rather than per call — the rolling loop calls
         # ``generate_chunk`` many times with the same shape, and a per-call warning would bury
         # the run's real output.

--- a/tests/grammar/conftest.py
+++ b/tests/grammar/conftest.py
@@ -54,7 +54,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("grammar", "End-to-end grammar-test fixture controls (see tests/grammar/)")
     group.addoption("--grammar-max-seq-len", type=int, default=16)
     group.addoption("--grammar-model-heads", type=int, default=4)
-    group.addoption("--grammar-model-head-dim", type=int, default=32)
+    group.addoption(
+        "--grammar-model-head-dim",
+        type=int,
+        default=32,
+        help=(
+            "Kept at 32 rather than raised to 64 for SGLang's sake: SGLang's default FlashInfer "
+            "attention backend cannot dispatch head dims below 64, but ``sglang_demo.yaml`` "
+            "selects the triton backend instead, which has no such floor. Widening the model here "
+            "would multiply the CPU pretrain cost of every grammar test to accommodate a backend "
+            "only one gated GPU test uses."
+        ),
+    )
     group.addoption("--grammar-pretrain-epochs", type=int, default=400)
     group.addoption("--grammar-pretrain-batch-size", type=int, default=32)
     group.addoption("--grammar-n-trajectories", type=int, default=8)

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -670,6 +670,17 @@ def test_small_head_dim_is_allowed_when_an_attention_backend_is_named(tmp_path: 
     assert fake.last_engine.engine_kwargs["attention_backend"] == "triton"
 
 
+def test_explicit_null_attention_backend_still_triggers_the_check(tmp_path: Path):
+    """``attention_backend: null`` is "let SGLang choose", not a choice, so the check must still fire.
+
+    ``sglang.yaml`` carries the key explicitly at ``null`` so it can be overridden without Hydra's
+    ``+`` syntax. That must not be mistaken for the caller having selected a backend.
+    """
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=32)
+    with pytest.raises(ValueError, match="FlashInfer"):
+        SGLangBackend(tmp_path, engine_kwargs={"attention_backend": None}, sgl_module=_FakeSGLModule())
+
+
 def test_head_dim_at_the_floor_is_allowed_on_the_default_attention_backend(tmp_path: Path):
     """The floor is inclusive — a model exactly at it must construct without complaint."""
     _write_config(tmp_path, max_position_embeddings=512, head_dim=_FLASHINFER_MIN_HEAD_DIM)

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from MEDS_EIC_AR.model.backends import GenerationBackend, SGLangBackend
 from MEDS_EIC_AR.model.backends.sglang import (
+    _FLASHINFER_MIN_HEAD_DIM,
     _SGLANG_CONTEXT_RESERVE,
     _pad_right_to_tensor,
     _strip_padding_to_lists,
@@ -633,3 +634,53 @@ def test_unreadable_config_leaves_the_budget_alone(tmp_path: Path):
     backend = SGLangBackend(tmp_path, sgl_module=fake)  # empty dir: no config.json
     assert backend._context_len is None
     assert _one_row_call(backend, fake, prompt_len=128, max_new_tokens=100_000)["max_new_tokens"] == 100_000
+
+
+# ---------------------------------------------------------------------------
+# Attention-backend / head-dim pre-flight
+# ---------------------------------------------------------------------------
+
+
+def _write_config(tmp_path: Path, **fields: Any) -> Path:
+    (tmp_path / "config.json").write_text(json.dumps(fields))
+    return tmp_path
+
+
+def test_small_head_dim_on_the_default_attention_backend_is_refused(tmp_path: Path):
+    """Constructing over a narrow model without naming an attention backend must raise.
+
+    SGLang would otherwise pick FlashInfer, which aborts the scheduler subprocess on head dims below its
+    floor. That abort reaches the parent as SIGQUIT / exit -9, so a shape constraint presents as an out-of-
+    memory kill — the error here exists to keep anyone from chasing memory.
+    """
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=32)
+    with pytest.raises(ValueError, match="FlashInfer"):
+        SGLangBackend(tmp_path, sgl_module=_FakeSGLModule())
+
+
+def test_small_head_dim_is_allowed_when_an_attention_backend_is_named(tmp_path: Path):
+    """Naming ``attention_backend`` explicitly is a deliberate choice and must be honored.
+
+    This is both the documented remedy (``sglang_demo.yaml`` sets ``triton`` for exactly this
+    reason) and the reason the check can't wrongly block a future FlashInfer that lifts the floor.
+    """
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=32)
+    fake = _FakeSGLModule()
+    SGLangBackend(tmp_path, engine_kwargs={"attention_backend": "triton"}, sgl_module=fake)
+    assert fake.last_engine.engine_kwargs["attention_backend"] == "triton"
+
+
+def test_head_dim_at_the_floor_is_allowed_on_the_default_attention_backend(tmp_path: Path):
+    """The floor is inclusive — a model exactly at it must construct without complaint."""
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=_FLASHINFER_MIN_HEAD_DIM)
+    SGLangBackend(tmp_path, sgl_module=_FakeSGLModule())
+
+
+def test_unknown_head_dim_does_not_block_construction(tmp_path: Path):
+    """A config without ``head_dim`` leaves nothing to check, and must not be treated as a failure.
+
+    Same principle as the unreadable-config case for the context ceiling: these are pre-flight
+    diagnostics, and none of them is worth refusing to construct the backend over.
+    """
+    _write_config(tmp_path, max_position_embeddings=512)
+    SGLangBackend(tmp_path, sgl_module=_FakeSGLModule())


### PR DESCRIPTION
Closes #163. **Stacked on #168** (issue #162), which introduces the config reader this generalizes —
review that one first.

The install recipe from part 1 of the issue already landed in 6202ced. This is the code and config
half: parts 2 and 3, plus the gated test's model shape.

## FlashInfer's head-dim floor

`SGLangBackend` now reads `head_dim` from the exported HF config and refuses to start when it is
below 64 **and** no `attention_backend` was named, with an error giving both remedies.

The reason this deserves a hard error rather than a doc note: the failure it prevents is an abort
inside the scheduler subprocess that reaches the parent as SIGQUIT / exit `-9`. A shape constraint
that presents as an out-of-memory kill sends you looking at memory, which is exactly where the time
goes.

Naming a backend explicitly is honored — that is both the documented remedy and what keeps this
check from wrongly blocking a future FlashInfer that lifts the floor. The check only fires when
*we* are the ones letting SGLang pick.

## The gated test's model shape

I went with the issue's second option rather than its first. `sglang_demo.yaml` now sets
`attention_backend: triton`, so `tests/grammar/test_cli_sglang.py` runs against the grammar
fixture's own model shape.

Raising `--grammar-model-head-dim` to 64 would have doubled the width of a model that every grammar
test pretrains on CPU — the fixture is already the dominant cost in `run_tests_ubuntu` — to
accommodate a backend that one gated GPU test uses. Triton has no floor and costs the CPU path
nothing. The knob keeps its 32 default and now carries that reasoning in its help text, so the next
person reading it doesn't re-file the same issue.

## mem_fraction_static

`sglang_demo.yaml` drops 0.85 → **0.3**; `sglang.yaml` keeps 0.85 with the caveat written down. Both
configs and the README now say explicitly that it is a fraction of *total* device memory reserved up
front, and that unified-memory hosts want a much lower number. 0.3 is ample for the models the demo
config targets and is safe on a dedicated GPU too.

## Also here

The config reader from #168 is generalized from context-length-only to "parse `config.json` once,
pull typed fields". Both users degrade to skipping their check rather than refusing to construct the
backend — these are pre-flight diagnostics, and none is worth failing a run over. The README's
FlashInfer bullet is updated to say the backend now catches this, and its `+backend.engine_kwargs...`
override loses the stray `+` (the key exists in both configs now).

## Testing

- Four new tests: refusal below the floor, acceptance when a backend is named, acceptance exactly at
  the floor, and no-check when `head_dim` is absent. Plus doctests on the reader and the guard.
- `uv run pytest --ignore=tests/grammar`: 116 passed, 4 skipped.
- `pre-commit run`: clean.

**Not verified on real hardware — no GPU here.** Worth confirming on the DGX Spark:

1. That `tests/grammar/test_cli_sglang.py` now passes with no `--grammar-model-head-dim` override,
   i.e. that `attention_backend: triton` really does carry `head_dim=32` end to end. This is the
   claim I'm least able to check, since it rests on triton having no floor.
2. That `mem_fraction_static: 0.3` is enough for the demo run there.
3. That 64 is the right floor for the installed `sglang==0.5.9` — it's from the issue's measurements
   (32 aborts, 64 works), and the constant records that provenance so it can be re-measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAbXzaro3Z6PvX5kkJSH2X
