### PR TITLE
fix: stop SGLang silently truncating the prompt (closes #171)

### DIFF
--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -109,30 +109,22 @@ _SGLANG_OUTPUT_KEYS: tuple[str, ...] = ("output_ids", "token_ids")
 _SGLANG_CONTEXT_RESERVE = 2
 
 
-#: Positions SGLang holds back from the *input* side of the context window.
+#: Fallback for SGLang's input ceiling when the engine doesn't report one.
 #:
-#: Distinct from :data:`_SGLANG_CONTEXT_RESERVE`, which bounds how many tokens SGLang will
-#: *emit*. This one bounds how many prompt tokens it will actually *read*, and exceeding it is
-#: far more damaging: SGLang does not refuse the request, it silently drops the tail of the
-#: prompt and generates from the truncated prefix, so the model is conditioned on something the
-#: caller never asked for. Derivation, from ``sglang==0.5.9``::
+#: SGLang bounds how many prompt tokens it will *read*, separately from how many it will emit
+#: (:data:`_SGLANG_CONTEXT_RESERVE`). Exceeding it is silent and destructive: the engine keeps
+#: the *oldest* tokens, discards the tail, and generates from that stale prefix, so the model is
+#: conditioned on something the caller never sent. From ``sglang==0.5.9``::
 #:
-#:     max_req_len       = min(context_len - 1, max_token_pool_size - 1)   # tp_worker.py
-#:     max_req_input_len = max_req_len - 5                                 # tp_worker.py
-#:     if len(input_ids) >= max_req_input_len: truncate or reject          # managers/utils.py
+#:     max_req_len       = min(context_len - 1, kv_pool_size - 1)   # managers/tp_worker.py
+#:     max_req_input_len = max_req_len - 5                          # managers/tp_worker.py
+#:     if len(input_ids) >= max_req_input_len: truncate             # managers/utils.py
 #:
-#: The comparison is ``>=``, so the longest prompt SGLang reads in full is
-#: ``max_req_input_len - 1``, i.e. ``context_len - 7`` whenever the context length is the
-#: binding term. Measured against a 16-position model: a 9-token prompt is honored, a 10-token
-#: prompt is already truncated.
-#:
-#: Why this is not merely SGLang's business: ``allow_auto_truncate=True`` (set unconditionally
-#: below) is what turns the rejection into a silent truncation, and SGLang's own truncation
-#: warning is emitted through a logger its engine init has already set to ERROR, so nothing
-#: surfaces. Left unchecked, ``Model._rolling_generate``'s default ``rolling_context_size`` of
-#: ``max_seq_len - 1`` sits far above this ceiling and every rolling chunk loses its prompt
-#: tail — which is exactly how SGLang came to emit grammar-invalid trajectories where the HF
-#: backend emitted valid ones (issue #171).
+#: The comparison is ``>=``, so the longest prompt read in full is ``max_req_input_len - 1``,
+#: i.e. ``context_len - 7`` when the context length is the binding term. Prefer the engine's own
+#: ``scheduler_info["max_req_input_len"]`` (see :meth:`SGLangBackend._resolve_max_prompt_len`),
+#: which also covers the case where the KV pool binds instead of the context; this constant is
+#: only the fallback for engines that don't report it.
 _SGLANG_INPUT_RESERVE = 7
 
 
@@ -409,22 +401,39 @@ class SGLangBackend:
         self._logged_context_clamp = False
         self._logged_prompt_ceiling = False
         self._engine = sgl_module.Engine(model_path=str(hf_model_dir), **self._engine_kwargs)
+        self._max_prompt_len = self._resolve_max_prompt_len()
         self._is_shutdown = False
         atexit.register(self.shutdown)
 
-    @property
-    def max_prompt_len(self) -> int | None:
-        """Longest prompt SGLang will read in full, or ``None`` if the context length is unknown.
+    def _resolve_max_prompt_len(self) -> int | None:
+        """Longest prompt this engine will read in full, or ``None`` if it can't be determined.
 
-        Prompts longer than this are silently truncated by the engine rather than rejected (see
-        :data:`_SGLANG_INPUT_RESERVE`), so callers that build their own prompt windows -- notably
-        :meth:`MEDS_EIC_AR.model.model.Model._rolling_generate` -- must clamp to this rather than
-        to the model's raw context length. ``None`` means "unknown, don't clamp", which restores
-        the pre-fix behavior rather than guessing a ceiling that might be wrong.
+        Asks the engine rather than re-deriving the arithmetic: ``scheduler_info`` carries the
+        ``max_req_input_len`` the scheduler actually enforces, so this tracks SGLang's own rule
+        across versions and accounts for the KV pool binding instead of the context length.
+        Subtracts one because SGLang's length check is ``>=``, not ``>``.
+
+        Falls back to :data:`_SGLANG_INPUT_RESERVE` against the model's context length when the
+        engine reports nothing (older SGLang, or a test double).
         """
+        info = getattr(self._engine, "scheduler_info", None)
+        reported = info.get("max_req_input_len") if isinstance(info, dict) else None
+        if isinstance(reported, int) and not isinstance(reported, bool) and reported > 0:
+            return reported - 1
         if self._context_len is None:
             return None
         return max(self._context_len - _SGLANG_INPUT_RESERVE, 0)
+
+    @property
+    def max_prompt_len(self) -> int | None:
+        """Longest prompt SGLang will read in full, or ``None`` if it could not be determined.
+
+        Prompts longer than this are silently truncated by the engine rather than rejected, so
+        callers that build their own prompt windows -- notably
+        :meth:`MEDS_EIC_AR.model.model.Model._rolling_generate` -- must size them against this
+        rather than the model's raw context length. ``None`` means "unknown, don't clamp".
+        """
+        return self._max_prompt_len
 
     def _check_prompt_len(self, prompt_len: int) -> None:
         """Refuse a prompt SGLang would silently truncate.

--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -109,6 +109,33 @@ _SGLANG_OUTPUT_KEYS: tuple[str, ...] = ("output_ids", "token_ids")
 _SGLANG_CONTEXT_RESERVE = 2
 
 
+#: Positions SGLang holds back from the *input* side of the context window.
+#:
+#: Distinct from :data:`_SGLANG_CONTEXT_RESERVE`, which bounds how many tokens SGLang will
+#: *emit*. This one bounds how many prompt tokens it will actually *read*, and exceeding it is
+#: far more damaging: SGLang does not refuse the request, it silently drops the tail of the
+#: prompt and generates from the truncated prefix, so the model is conditioned on something the
+#: caller never asked for. Derivation, from ``sglang==0.5.9``::
+#:
+#:     max_req_len       = min(context_len - 1, max_token_pool_size - 1)   # tp_worker.py
+#:     max_req_input_len = max_req_len - 5                                 # tp_worker.py
+#:     if len(input_ids) >= max_req_input_len: truncate or reject          # managers/utils.py
+#:
+#: The comparison is ``>=``, so the longest prompt SGLang reads in full is
+#: ``max_req_input_len - 1``, i.e. ``context_len - 7`` whenever the context length is the
+#: binding term. Measured against a 16-position model: a 9-token prompt is honored, a 10-token
+#: prompt is already truncated.
+#:
+#: Why this is not merely SGLang's business: ``allow_auto_truncate=True`` (set unconditionally
+#: below) is what turns the rejection into a silent truncation, and SGLang's own truncation
+#: warning is emitted through a logger its engine init has already set to ERROR, so nothing
+#: surfaces. Left unchecked, ``Model._rolling_generate``'s default ``rolling_context_size`` of
+#: ``max_seq_len - 1`` sits far above this ceiling and every rolling chunk loses its prompt
+#: tail — which is exactly how SGLang came to emit grammar-invalid trajectories where the HF
+#: backend emitted valid ones (issue #171).
+_SGLANG_INPUT_RESERVE = 7
+
+
 #: Smallest attention head dimension SGLang's default FlashInfer attention backend can dispatch.
 #: Below this it aborts the scheduler subprocess with ``FlashInfer Internal Error: Invalid
 #: configuration``, which reaches the parent as SIGQUIT / exit ``-9`` — indistinguishable at a
@@ -380,9 +407,46 @@ class SGLangBackend:
         # ``generate_chunk`` many times with the same shape, and a per-call warning would bury
         # the run's real output.
         self._logged_context_clamp = False
+        self._logged_prompt_ceiling = False
         self._engine = sgl_module.Engine(model_path=str(hf_model_dir), **self._engine_kwargs)
         self._is_shutdown = False
         atexit.register(self.shutdown)
+
+    @property
+    def max_prompt_len(self) -> int | None:
+        """Longest prompt SGLang will read in full, or ``None`` if the context length is unknown.
+
+        Prompts longer than this are silently truncated by the engine rather than rejected (see
+        :data:`_SGLANG_INPUT_RESERVE`), so callers that build their own prompt windows -- notably
+        :meth:`MEDS_EIC_AR.model.model.Model._rolling_generate` -- must clamp to this rather than
+        to the model's raw context length. ``None`` means "unknown, don't clamp", which restores
+        the pre-fix behavior rather than guessing a ceiling that might be wrong.
+        """
+        if self._context_len is None:
+            return None
+        return max(self._context_len - _SGLANG_INPUT_RESERVE, 0)
+
+    def _check_prompt_len(self, prompt_len: int) -> None:
+        """Refuse a prompt SGLang would silently truncate.
+
+        Raising beats the alternative: SGLang would accept the request, drop the tail of the
+        prompt, and return tokens conditioned on a prefix the caller never asked for. That is
+        invisible at the API surface -- the output has the right shape and the right length --
+        and it is what produced grammar-invalid trajectories in issue #171.
+        """
+        ceiling = self.max_prompt_len
+        if ceiling is None or prompt_len <= ceiling:
+            return
+        raise ValueError(
+            f"SGLang would silently truncate this {prompt_len}-token prompt: on a "
+            f"{self._context_len}-position model it reads at most {ceiling} prompt tokens "
+            f"(max_req_input_len = min(context_len - 1, kv_pool - 1) - 5, compared with >=). "
+            "It does not reject the request -- it drops the tail and generates from the "
+            "remaining prefix, so the model would be conditioned on something you did not ask "
+            "for. The HF backend has no such limit. Lower the prompt window to at most "
+            f"{ceiling} tokens (for rolling generation, set "
+            f"rolling_generation.rolling_context_size<={ceiling})."
+        )
 
     def _cap_max_new_tokens(self, requested: int, prompt_len: int) -> int:
         """Clamp ``requested`` to what SGLang will actually honor for a ``prompt_len``-token prompt.
@@ -494,9 +558,11 @@ class SGLangBackend:
         # binding one, since ``max_new_tokens`` is shared across the whole call). Doing it here
         # rather than leaving it to ``allow_auto_truncate`` is what makes the shortfall visible;
         # see ``_SGLANG_CONTEXT_RESERVE``.
-        max_new_tokens = self._cap_max_new_tokens(
-            generation_config.max_new_tokens, max((len(p) for p in prompts), default=0)
-        )
+        longest_prompt = max((len(p) for p in prompts), default=0)
+        # Input ceiling first: an over-long prompt is silently truncated by the engine, which is
+        # strictly worse than the output-side shortfall handled just below.
+        self._check_prompt_len(longest_prompt)
+        max_new_tokens = self._cap_max_new_tokens(generation_config.max_new_tokens, longest_prompt)
 
         # Map HF ``GenerationConfig`` → SGLang sampling-params dict. Intentional translations:
         #   - ``do_sample=False`` → ``temperature=0.0`` regardless of the caller's configured

--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -44,14 +44,14 @@ Gotchas accounted for:
 from __future__ import annotations
 
 import atexit
-import json
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import torch
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from transformers import GenerationConfig
 
 logger = logging.getLogger(__name__)
@@ -80,52 +80,27 @@ _HF_ONLY_KWARGS: frozenset[str] = frozenset(
 #: if neither key is found we raise loudly (see ``generate_chunk``).
 _SGLANG_OUTPUT_KEYS: tuple[str, ...] = ("output_ids", "token_ids")
 
-#: Positions SGLang holds back from the model's context window, on top of the prompt.
+#: Gap between SGLang's two per-request limits, i.e. ``max_req_len - max_req_input_len``.
 #:
-#: Two layers are involved and only the second costs tokens. The tokenizer manager checks
-#: ``len(input) + max_new_tokens >= context_len`` and either raises or, under
-#: ``allow_auto_truncate``, clamps to ``context_len - len(input)`` — a no-op at exactly the
-#: boundary. The *scheduler* is what actually trims, in ``init_req_max_new_tokens``::
-#:
-#:     max_req_len    = min(context_len - 1, max_token_pool_size - 1)   # tp_worker
-#:     max_new_tokens = min(requested, max_req_len - len(input) - 1)    # scheduler
-#:
-#: which is ``context_len - len(input) - 2`` whenever the context length is the binding term.
-#: That ``min`` is unconditional: no warning, and not gated on ``allow_auto_truncate``. HF's
-#: ``generate``, by contrast, will fill the window exactly. Matches the measurement it was
-#: derived from — on a 512-position model with a 128-token prompt, 382 new tokens is the largest
-#: request honored in full, while 383 and 384 both come back as 382.
-#:
-#: **Two is a floor, not a guarantee.** When the KV pool is the binding term instead — a large
-#: model, or a small ``mem_fraction_static`` — ``max_req_len`` is smaller than ``context_len - 1``
-#: and the shortfall grows. Capping by this constant keeps the common case honest; the residual is
-#: what ``allow_auto_truncate`` is left on to absorb.
-#:
-#: The subtraction also goes negative: at ``len(input) == context_len - 1`` the scheduler's cap is
-#: ``-1``, and ``Req.check_finished`` stops on ``len(output_ids) >= max_new_tokens``, which holds
-#: at zero output tokens. The request completes having generated nothing — which is why
-#: :meth:`SGLangBackend._cap_max_new_tokens` raises rather than letting the rolling loop receive an
-#: empty chunk it would spin on.
-_SGLANG_CONTEXT_RESERVE = 2
-
-
-#: Fallback for SGLang's input ceiling when the engine doesn't report one.
-#:
-#: SGLang bounds how many prompt tokens it will *read*, separately from how many it will emit
-#: (:data:`_SGLANG_CONTEXT_RESERVE`). Exceeding it is silent and destructive: the engine keeps
-#: the *oldest* tokens, discards the tail, and generates from that stale prefix, so the model is
-#: conditioned on something the caller never sent. From ``sglang==0.5.9``::
+#: Both of SGLang's request ceilings derive from one quantity, and only one of them is reported
+#: by the engine, so this constant bridges them (``sglang==0.5.9``)::
 #:
 #:     max_req_len       = min(context_len - 1, kv_pool_size - 1)   # managers/tp_worker.py
 #:     max_req_input_len = max_req_len - 5                          # managers/tp_worker.py
-#:     if len(input_ids) >= max_req_input_len: truncate             # managers/utils.py
 #:
-#: The comparison is ``>=``, so the longest prompt read in full is ``max_req_input_len - 1``,
-#: i.e. ``context_len - 7`` when the context length is the binding term. Prefer the engine's own
-#: ``scheduler_info["max_req_input_len"]`` (see :meth:`SGLangBackend._resolve_max_prompt_len`),
-#: which also covers the case where the KV pool binds instead of the context; this constant is
-#: only the fallback for engines that don't report it.
-_SGLANG_INPUT_RESERVE = 7
+#: ``scheduler_info`` reports ``max_req_input_len``, from which ``max_req_len`` follows. Deriving
+#: both ceilings from the reported value keeps them correct when the KV pool binds rather than
+#: the context length -- a case no config-file arithmetic can see.
+#:
+#: The two ceilings behave very differently when exceeded:
+#:
+#: * **Input** (``len(input_ids) >= max_req_input_len``, managers/utils.py): the engine keeps the
+#:   *oldest* tokens and discards the tail, then generates from that stale prefix. Silent, and
+#:   it corrupts the conditioning rather than merely shortening it, so the adapter refuses such
+#:   prompts outright.
+#: * **Output** (``max_new_tokens = max_req_len - len(input) - 1``, managers/scheduler.py): the
+#:   request simply emits fewer tokens than asked. Harmless in itself, but worth surfacing.
+_SGLANG_MAX_REQ_LEN_GAP = 5
 
 
 #: Smallest attention head dimension SGLang's default FlashInfer attention backend can dispatch.
@@ -136,81 +111,74 @@ _SGLANG_INPUT_RESERVE = 7
 #: backend has no such floor.
 _FLASHINFER_MIN_HEAD_DIM = 64
 
+#: What SGLang selects when ``attention_backend`` is left unset.
+_SGLANG_DEFAULT_ATTENTION_BACKEND = "flashinfer"
 
-def _read_hf_config(hf_model_dir: Path | str) -> dict:
-    """Parse an HF model directory's ``config.json``, or return ``{}`` if it can't be read.
 
-    Degrading to an empty dict rather than raising is deliberate: every use of this config is a
-    pre-flight check that improves diagnostics, and none of them is worth refusing to construct
-    the backend over. A missing config costs the checks, not the run.
+def _read_hf_config_value(hf_model_dir: Path | str, key: str) -> int | None:
+    """Read one integer field from an HF model directory's config, or ``None`` if unavailable.
+
+    Uses ``transformers``' own config loader rather than parsing ``config.json`` by hand, so
+    derived and aliased fields resolve the way the model itself sees them (``head_dim``, for
+    one, is filled in from ``hidden_size / num_attention_heads`` when absent from the file).
+
+    Returns ``None`` rather than raising when the directory has no readable config or the field
+    is missing: the only caller is a pre-flight diagnostic, and losing it is worth less than
+    refusing to construct the backend.
 
     Examples:
         >>> import json, tempfile
         >>> from pathlib import Path
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = (Path(d) / "config.json").write_text(json.dumps({"head_dim": 64}))
-        ...     _read_hf_config(d)
-        {'head_dim': 64}
+        ...     _ = (Path(d) / "config.json").write_text(json.dumps({
+        ...         "model_type": "llama", "hidden_size": 128, "num_attention_heads": 4,
+        ...     }))
+        ...     _read_hf_config_value(d, "head_dim")
+        32
 
-        Missing and malformed configs both degrade to ``{}``:
+        Missing config, or a field the config doesn't carry, both give ``None``:
 
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _read_hf_config(d)
-        {}
+        ...     print(_read_hf_config_value(d, "head_dim"))
+        None
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = (Path(d) / "config.json").write_text("{not json")
-        ...     _read_hf_config(d)
-        {}
+        ...     _ = (Path(d) / "config.json").write_text(json.dumps({
+        ...         "model_type": "llama", "hidden_size": 128, "num_attention_heads": 4,
+        ...     }))
+        ...     print(_read_hf_config_value(d, "not_a_field"))
+        None
     """
-    config_fp = Path(hf_model_dir) / "config.json"
+    from transformers import AutoConfig
+
     try:
-        config = json.loads(config_fp.read_text())
-    except (OSError, ValueError) as e:
+        config = AutoConfig.from_pretrained(str(hf_model_dir))
+    except Exception as e:  # any load failure just costs us the pre-flight check
         logger.warning(
-            f"Could not read {config_fp} ({type(e).__name__}: {e}). The SGLang backend's "
-            "pre-flight checks on context length and attention head dimension will be skipped."
+            f"Could not load an HF config from {hf_model_dir} ({type(e).__name__}: {e}). The "
+            "SGLang backend's attention-head-dimension pre-flight check will be skipped."
         )
-        return {}
-    return config if isinstance(config, dict) else {}
+        return None
 
-
-def _config_int(config: dict, key: str) -> int | None:
-    """Pull an integer field out of a parsed HF config, or ``None`` if it isn't there.
-
-    Examples:
-        >>> _config_int({"head_dim": 64}, "head_dim")
-        64
-        >>> print(_config_int({}, "head_dim"))
-        None
-        >>> print(_config_int({"head_dim": None}, "head_dim"))
-        None
-        >>> print(_config_int({"head_dim": "64"}, "head_dim"))
-        None
-
-        ``bool`` is a subclass of ``int`` but never a valid answer here:
-
-        >>> print(_config_int({"head_dim": True}, "head_dim"))
-        None
-    """
-    value = config.get(key)
+    value = getattr(config, key, None)
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value
 
 
-def _check_head_dim_against_attention_backend(head_dim: int | None, engine_kwargs: dict) -> None:
-    """Refuse to start SGLang on a default attention backend that cannot dispatch this head dim.
+def _check_attention_backend(head_dim: int | None, engine_kwargs: dict) -> None:
+    """Validate the requested attention backend, and its head-dim floor if it has one.
 
-    SGLang defaults to FlashInfer, which aborts on ``head_dim`` below
-    :data:`_FLASHINFER_MIN_HEAD_DIM`. The abort kills the scheduler subprocess and surfaces in the
-    parent as SIGQUIT / exit ``-9``, so what is really a shape constraint reads as an
-    out-of-memory kill — the single most misleading failure this backend can produce. Catching it
-    here costs nothing and names both remedies.
+    Two failures worth catching before the engine starts:
 
-    The check only fires when ``attention_backend`` is left unset, i.e. when *we* are the ones
-    letting SGLang pick FlashInfer. A caller who names a backend explicitly has made a choice and
-    is trusted with it, which also means this cannot wrongly block a future FlashInfer that lifts
-    the floor.
+    * An unrecognized backend name. SGLang would reject it, but later and less clearly.
+    * FlashInfer below :data:`_FLASHINFER_MIN_HEAD_DIM`. FlashInfer aborts the scheduler
+      subprocess with ``FlashInfer Internal Error: Invalid configuration``, which reaches the
+      parent as SIGQUIT / exit ``-9`` — indistinguishable at a glance from an out-of-memory
+      kill, and so a genuinely expensive thing to debug.
+
+    The floor applies whenever FlashInfer is what will actually run, whether it was named
+    explicitly or left to SGLang to choose. Naming it does not make it work. Backends other than
+    FlashInfer are left alone: the floor is FlashInfer's, not a general one.
 
     Args:
         head_dim: The model's attention head dimension, or ``None`` if it could not be read (in
@@ -218,35 +186,65 @@ def _check_head_dim_against_attention_backend(head_dim: int | None, engine_kwarg
         engine_kwargs: The kwargs about to be passed to ``sglang.Engine``.
 
     Raises:
-        ValueError: If the head dimension is below the FlashInfer floor and no attention backend
-            was named.
+        ValueError: If the backend name is unrecognized, or FlashInfer would run below its floor.
 
     Examples:
-        Fine: head dim at or above the floor, or unknown, or a backend named explicitly.
+        Fine: at or above the floor, unknown head dim, or a backend without the floor.
 
-        >>> _check_head_dim_against_attention_backend(64, {})
-        >>> _check_head_dim_against_attention_backend(None, {})
-        >>> _check_head_dim_against_attention_backend(32, {"attention_backend": "triton"})
+        >>> _check_attention_backend(64, {})
+        >>> _check_attention_backend(None, {})
+        >>> _check_attention_backend(32, {"attention_backend": "triton"})
 
-        Refused: below the floor with the backend left to SGLang's default.
+        Refused below the floor, whether FlashInfer is implicit (``None``/absent) or explicit:
 
-        >>> _check_head_dim_against_attention_backend(32, {})
+        >>> _check_attention_backend(32, {})
         Traceback (most recent call last):
             ...
-        ValueError: SGLang's default FlashInfer attention backend cannot dispatch
-        attention_head_dim=32 ...
+        ValueError: SGLang's FlashInfer attention backend cannot dispatch attention_head_dim=32 ...
+        >>> _check_attention_backend(32, {"attention_backend": None})
+        Traceback (most recent call last):
+            ...
+        ValueError: SGLang's FlashInfer attention backend cannot dispatch attention_head_dim=32 ...
+        >>> _check_attention_backend(32, {"attention_backend": "flashinfer"})
+        Traceback (most recent call last):
+            ...
+        ValueError: SGLang's FlashInfer attention backend cannot dispatch attention_head_dim=32 ...
+
+        An unrecognized name is refused regardless of head dim:
+
+        >>> _check_attention_backend(128, {"attention_backend": "flashinfer_typo"})
+        Traceback (most recent call last):
+            ...
+        ValueError: Unknown SGLang attention_backend 'flashinfer_typo'. Valid choices: ...
     """
+    requested = engine_kwargs.get("attention_backend")
+
+    if requested is not None:
+        try:
+            from sglang.srt.server_args import ATTENTION_BACKEND_CHOICES
+
+            valid = set(ATTENTION_BACKEND_CHOICES)
+        except ImportError:  # pragma: no cover — only if SGLang moves the constant
+            valid = set()
+        if valid and requested not in valid:
+            raise ValueError(
+                f"Unknown SGLang attention_backend {requested!r}. Valid choices: {', '.join(sorted(valid))}."
+            )
+
+    # ``None``/absent means SGLang picks, and it picks FlashInfer.
+    if requested not in (None, _SGLANG_DEFAULT_ATTENTION_BACKEND):
+        return
     if head_dim is None or head_dim >= _FLASHINFER_MIN_HEAD_DIM:
         return
-    if engine_kwargs.get("attention_backend") is not None:
-        return
+    how_selected = "explicitly selected" if requested else "SGLang's default when none is named"
     raise ValueError(
-        f"SGLang's default FlashInfer attention backend cannot dispatch attention_head_dim="
-        f"{head_dim} (its floor is {_FLASHINFER_MIN_HEAD_DIM}). It would abort the scheduler "
-        "subprocess with 'FlashInfer Internal Error: Invalid configuration', which reaches this "
-        "process as SIGQUIT / exit -9 and looks like an out-of-memory kill rather than a shape "
-        "error. Either train with lightning_module.model.gpt_kwargs.attention_head_dim>="
-        f"{_FLASHINFER_MIN_HEAD_DIM}, or select an attention backend that has no such floor with "
+        f"SGLang's FlashInfer attention backend cannot dispatch attention_head_dim={head_dim} "
+        f"(its floor is {_FLASHINFER_MIN_HEAD_DIM}); it is {how_selected}. It "
+        "would abort the scheduler subprocess with 'FlashInfer Internal Error: Invalid "
+        "configuration', which reaches this process as SIGQUIT / exit -9 and looks like an "
+        "out-of-memory kill rather than a shape error. Either train with "
+        f"lightning_module.model.gpt_kwargs.attention_head_dim>={_FLASHINFER_MIN_HEAD_DIM}, or "
+        "select an attention backend that has no such floor with "
         "backend.engine_kwargs.attention_backend=triton."
     )
 
@@ -381,123 +379,105 @@ class SGLangBackend:
         # ``max_context_length`` exactly. HF's ``generate`` accepts that boundary (positions
         # ``0..max_pos-1`` inclusive); SGLang's tokenizer manager raises on it unless this flag is
         # set. The token loss happens further in, in the scheduler, and happens either way — see
-        # ``_SGLANG_CONTEXT_RESERVE``. So this flag is what keeps boundary requests alive, and
+        # ``_SGLANG_MAX_REQ_LEN_GAP``. So this flag is what keeps boundary requests alive, and
         # :meth:`generate_chunk` is what makes the resulting shortfall visible instead of leaving
         # it to be discovered in the output shape. Non-overridable for the same reason as
         # ``skip_tokenizer_init``: turning it off converts every window-saturating chunk from a
-        # shortfall into a crash mid-run.
+        # shortfall into a crash mid-run. The *input* ceiling is enforced by this adapter instead,
+        # since auto-truncation there is silently destructive rather than merely lossy.
         self._engine_kwargs["allow_auto_truncate"] = True
-        hf_config = _read_hf_config(hf_model_dir)
-        self._context_len = _config_int(hf_config, "max_position_embeddings")
-        if self._context_len is None:
-            logger.warning(
-                f"No integer ``max_position_embeddings`` in {Path(hf_model_dir) / 'config.json'}; "
-                "SGLang's own auto-truncation will apply instead, which clamps silently."
-            )
-        _check_head_dim_against_attention_backend(_config_int(hf_config, "head_dim"), self._engine_kwargs)
-        # Log the ceiling once at construction rather than per call — the rolling loop calls
+        _check_attention_backend(_read_hf_config_value(hf_model_dir, "head_dim"), self._engine_kwargs)
+        # Log the shortfall once at construction rather than per call — the rolling loop calls
         # ``generate_chunk`` many times with the same shape, and a per-call warning would bury
         # the run's real output.
         self._logged_context_clamp = False
-        self._logged_prompt_ceiling = False
         self._engine = sgl_module.Engine(model_path=str(hf_model_dir), **self._engine_kwargs)
-        self._max_prompt_len = self._resolve_max_prompt_len()
+        self._max_req_input_len = self._read_max_req_input_len()
         self._is_shutdown = False
         atexit.register(self.shutdown)
 
-    def _resolve_max_prompt_len(self) -> int | None:
-        """Longest prompt this engine will read in full, or ``None`` if it can't be determined.
+    def _read_max_req_input_len(self) -> int:
+        """Read the engine's own ``max_req_input_len``.
 
-        Asks the engine rather than re-deriving the arithmetic: ``scheduler_info`` carries the
-        ``max_req_input_len`` the scheduler actually enforces, so this tracks SGLang's own rule
-        across versions and accounts for the KV pool binding instead of the context length.
-        Subtracts one because SGLang's length check is ``>=``, not ``>``.
-
-        Falls back to :data:`_SGLANG_INPUT_RESERVE` against the model's context length when the
-        engine reports nothing (older SGLang, or a test double).
+        Asked of the engine rather than re-derived from the model config so it tracks SGLang's rule across
+        versions and stays correct when the KV pool binds instead of the context length. Raises rather than
+        guessing: a wrong ceiling here is silently destructive, since an over-long prompt is truncated by the
+        engine rather than rejected.
         """
         info = getattr(self._engine, "scheduler_info", None)
         reported = info.get("max_req_input_len") if isinstance(info, dict) else None
-        if isinstance(reported, int) and not isinstance(reported, bool) and reported > 0:
-            return reported - 1
-        if self._context_len is None:
-            return None
-        return max(self._context_len - _SGLANG_INPUT_RESERVE, 0)
+        if not isinstance(reported, int) or isinstance(reported, bool) or reported <= 0:
+            raise RuntimeError(
+                "SGLang did not report a usable ``max_req_input_len`` in ``scheduler_info`` "
+                f"(got {reported!r} from {info!r}). The adapter needs it to know how many prompt "
+                "tokens the engine will actually read: past that limit SGLang silently discards "
+                "the tail of the prompt instead of rejecting it, so proceeding without the "
+                "ceiling risks generating from a truncated context. This is expected on "
+                "sglang>=0.4; if a newer release moved the field, the adapter needs updating."
+            )
+        if reported - 1 <= 0:
+            raise RuntimeError(
+                f"SGLang reports max_req_input_len={reported}, leaving no room for a prompt on "
+                "this model. Its context window is too small to generate from."
+            )
+        return reported
 
     @property
-    def max_prompt_len(self) -> int | None:
-        """Longest prompt SGLang will read in full, or ``None`` if it could not be determined.
+    def max_prompt_len(self) -> int:
+        """Longest prompt SGLang will read in full.
 
         Prompts longer than this are silently truncated by the engine rather than rejected, so
         callers that build their own prompt windows -- notably
         :meth:`MEDS_EIC_AR.model.model.Model._rolling_generate` -- must size them against this
-        rather than the model's raw context length. ``None`` means "unknown, don't clamp".
+        rather than the model's raw context length. One less than the engine's reported
+        ``max_req_input_len`` because SGLang's length check is ``>=``, not ``>``.
         """
-        return self._max_prompt_len
+        return self._max_req_input_len - 1
+
+    @property
+    def _max_req_len(self) -> int:
+        """SGLang's per-request total-length ceiling (prompt + generated)."""
+        return self._max_req_input_len + _SGLANG_MAX_REQ_LEN_GAP
 
     def _check_prompt_len(self, prompt_len: int) -> None:
         """Refuse a prompt SGLang would silently truncate.
 
         Raising beats the alternative: SGLang would accept the request, drop the tail of the
         prompt, and return tokens conditioned on a prefix the caller never asked for. That is
-        invisible at the API surface -- the output has the right shape and the right length --
-        and it is what produced grammar-invalid trajectories in issue #171.
+        invisible at the API surface -- the output has the right shape and the right length.
         """
-        ceiling = self.max_prompt_len
-        if ceiling is None or prompt_len <= ceiling:
+        if prompt_len <= self.max_prompt_len:
             return
         raise ValueError(
-            f"SGLang would silently truncate this {prompt_len}-token prompt: on a "
-            f"{self._context_len}-position model it reads at most {ceiling} prompt tokens "
-            f"(max_req_input_len = min(context_len - 1, kv_pool - 1) - 5, compared with >=). "
-            "It does not reject the request -- it drops the tail and generates from the "
-            "remaining prefix, so the model would be conditioned on something you did not ask "
-            "for. The HF backend has no such limit. Lower the prompt window to at most "
-            f"{ceiling} tokens (for rolling generation, set "
-            f"rolling_generation.rolling_context_size<={ceiling})."
+            f"SGLang would silently truncate this {prompt_len}-token prompt: it reads at most "
+            f"{self.max_prompt_len} prompt tokens (engine-reported max_req_input_len="
+            f"{self._max_req_input_len}, compared with >=). It does not reject the request -- it "
+            "keeps the oldest tokens, drops the tail, and generates from what remains, so the "
+            "model would be conditioned on something you did not ask for. The HF backend has no "
+            f"such limit. Lower the prompt window to at most {self.max_prompt_len} tokens (for "
+            f"rolling generation, set rolling_generation.rolling_context_size<={self.max_prompt_len})."
         )
 
     def _cap_max_new_tokens(self, requested: int, prompt_len: int) -> int:
-        """Clamp ``requested`` to what SGLang will actually honor for a ``prompt_len``-token prompt.
+        """Clamp ``requested`` to what SGLang will actually emit for a ``prompt_len``-token prompt.
 
-        Returns ``requested`` unchanged when the model's context length could not be read (in
-        which case we fall back to the engine's own auto-truncate) or when the request already
-        fits. Otherwise returns the ceiling and logs the shortfall once.
-
-        Raises:
-            ValueError: If the prompt is so long that no new tokens fit under the ceiling. This is
-                reachable from the rolling loop, whose default ``rolling_context_size`` of
-                ``max_seq_len - 1`` leaves only one position for new tokens — one fewer than the
-                reserve needs. Raising beats returning an empty chunk, which the rolling loop
-                would read as "no progress" and spin on forever.
+        SGLang's scheduler caps ``max_new_tokens`` at ``max_req_len - len(input) - 1``, so a
+        request that would fill the window comes back short. Applying the cap here rather than
+        leaving it to the engine is what makes the shortfall visible; the shortfall itself is
+        unavoidable. Unlike the input ceiling this is not corrupting -- the tokens returned are
+        correct, there are just fewer of them.
         """
-        if self._context_len is None:
-            return requested
-
-        allowed = self._context_len - prompt_len - _SGLANG_CONTEXT_RESERVE
+        allowed = self._max_req_len - prompt_len - 1
         if allowed >= requested:
             return requested
-
-        if allowed <= 0:
-            raise ValueError(
-                f"SGLang cannot generate any new tokens for a {prompt_len}-token prompt against a "
-                f"{self._context_len}-position context window: its scheduler caps max_new_tokens "
-                f"at max_req_len - len(input) - 1, which holds back {_SGLANG_CONTEXT_RESERVE} "
-                f"positions and leaves {allowed} here. At or past this point SGLang returns an "
-                "empty completion rather than an error, which the rolling loop would read as no "
-                "progress and spin on. HF's generate accepts this prompt, so the ceiling is "
-                "SGLang-specific. Set rolling_generation.rolling_context_size to at most "
-                f"{self._context_len - _SGLANG_CONTEXT_RESERVE - 1} so every chunk has room for at "
-                "least one new token."
-            )
 
         if not self._logged_context_clamp:
             self._logged_context_clamp = True
             logger.warning(
                 f"SGLang chunk budget clamped from {requested} to {allowed} new tokens for a "
-                f"{prompt_len}-token prompt: its scheduler holds back "
-                f"{_SGLANG_CONTEXT_RESERVE} of the model's {self._context_len} positions, where "
-                "HF's generate would use the full window. Generated trajectories will be "
+                f"{prompt_len}-token prompt: its scheduler caps max_new_tokens at "
+                f"max_req_len - len(input) - 1 (max_req_len={self._max_req_len}), where HF's "
+                "generate would use the full window. Generated trajectories will be "
                 "correspondingly shorter than the HF backend's on window-saturating chunks. "
                 "Logged once per backend instance."
             )
@@ -548,10 +528,10 @@ class SGLangBackend:
         subprocess. The stripped kwargs are logged at debug level.
 
         ``generation_config.max_new_tokens`` is a request, not a guarantee: SGLang reserves
-        ``_SGLANG_CONTEXT_RESERVE`` positions of the model's context window that HF's ``generate``
-        would happily use, so a window-saturating chunk comes back that many tokens shorter. The
-        shortfall is applied here and logged rather than left to the engine to swallow; see
-        :meth:`_cap_max_new_tokens`.
+        a few positions of the model's context window that HF's ``generate`` would happily use, so a
+        window-saturating chunk comes back correspondingly shorter. The shortfall is applied here
+        and logged rather than left to the engine to swallow; see :meth:`_cap_max_new_tokens`.
+        An over-long *prompt* is refused outright instead -- see :meth:`_check_prompt_len`.
         """
         stripped = {k: v for k, v in kwargs.items() if k in _HF_ONLY_KWARGS}
         if stripped:
@@ -565,8 +545,7 @@ class SGLangBackend:
 
         # Apply SGLang's context ceiling ourselves, against the longest prompt in the batch (the
         # binding one, since ``max_new_tokens`` is shared across the whole call). Doing it here
-        # rather than leaving it to ``allow_auto_truncate`` is what makes the shortfall visible;
-        # see ``_SGLANG_CONTEXT_RESERVE``.
+        # rather than leaving it to ``allow_auto_truncate`` is what makes the shortfall visible.
         longest_prompt = max((len(p) for p in prompts), default=0)
         # Input ceiling first: an over-long prompt is silently truncated by the engine, which is
         # strictly worse than the output-side shortfall handled just below.

--- a/src/MEDS_EIC_AR/model/backends/sglang.py
+++ b/src/MEDS_EIC_AR/model/backends/sglang.py
@@ -210,12 +210,11 @@ def _check_attention_backend(head_dim: int | None, engine_kwargs: dict) -> None:
             ...
         ValueError: SGLang's FlashInfer attention backend cannot dispatch attention_head_dim=32 ...
 
-        An unrecognized name is refused regardless of head dim:
-
-        >>> _check_attention_backend(128, {"attention_backend": "flashinfer_typo"})
-        Traceback (most recent call last):
-            ...
-        ValueError: Unknown SGLang attention_backend 'flashinfer_typo'. Valid choices: ...
+        An unrecognized name is also refused, regardless of head dim -- but only when ``sglang``
+        is installed, since its ``ATTENTION_BACKEND_CHOICES`` is what defines "recognized". With
+        the package absent (the backend is reachable in that state only via an injected
+        ``sgl_module``) the name check is skipped rather than guessing at a hard-coded list. See
+        ``test_unknown_attention_backend_is_refused``.
     """
     requested = engine_kwargs.get("attention_backend")
 

--- a/src/MEDS_EIC_AR/model/model.py
+++ b/src/MEDS_EIC_AR/model/model.py
@@ -897,13 +897,12 @@ class Model(torch.nn.Module):
         if max_new_tokens <= 0:
             raise ValueError(f"max_new_tokens must be positive; got {max_new_tokens}.")
 
-        # The prompt window is bounded by the model's context, but a backend may read fewer
-        # prompt tokens than the model can represent. SGLang is one: it reads at most
-        # ``context_len - 7`` and *silently truncates* anything longer, so a window sized to
-        # ``max_seq_len - 1`` would lose its tail on every chunk and condition the model on a
-        # prefix nobody asked for (issue #171). Backends advertise the limit via an optional
-        # ``max_prompt_len``; ``None`` (and the HF backend, which has no such limit) means
-        # "model context is the only bound", preserving previous behavior.
+        # The prompt window is bounded by the model's context, and possibly further by the
+        # backend: some engines read fewer prompt tokens than the model can represent and
+        # silently discard the rest, which corrupts the conditioning rather than merely
+        # shortening it. Backends advertise that limit via an optional ``max_prompt_len``;
+        # ``None`` (the HF backend, which has no such limit) means the model context is the only
+        # bound.
         ctx_cap = self.max_seq_len - 1
         backend_cap = getattr(self._backend, "max_prompt_len", None)
         if backend_cap is not None:
@@ -916,11 +915,29 @@ class Model(torch.nn.Module):
             ctx_cap = min(ctx_cap, backend_cap)
 
         if rolling_context_size is None:
+            # Unspecified: take the largest window everything involved can honor.
             ctx_size = ctx_cap
         else:
+            # Specified: refuse anything unattainable rather than quietly shrinking it, so a run
+            # never conditions on less history than it was told to.
             if rolling_context_size <= 0:
                 raise ValueError(f"rolling_context_size must be positive; got {rolling_context_size}.")
-            ctx_size = min(rolling_context_size, ctx_cap)
+            if rolling_context_size > ctx_cap:
+                bound = (
+                    f"the model's context window (max_seq_len={self.max_seq_len}, so at most "
+                    f"{self.max_seq_len - 1})"
+                    if ctx_cap == self.max_seq_len - 1
+                    else (
+                        f"{type(self._backend).__name__}, which reads at most {backend_cap} prompt "
+                        "tokens and silently discards the rest"
+                    )
+                )
+                raise ValueError(
+                    f"rolling_context_size={rolling_context_size} exceeds what is usable here: "
+                    f"{bound}. Lower it to at most {ctx_cap}, or leave it unset to use the "
+                    "largest usable window automatically."
+                )
+            ctx_size = rolling_context_size
 
         input_ids = batch.code
         pad_id = batch.PAD_INDEX

--- a/src/MEDS_EIC_AR/model/model.py
+++ b/src/MEDS_EIC_AR/model/model.py
@@ -897,12 +897,30 @@ class Model(torch.nn.Module):
         if max_new_tokens <= 0:
             raise ValueError(f"max_new_tokens must be positive; got {max_new_tokens}.")
 
+        # The prompt window is bounded by the model's context, but a backend may read fewer
+        # prompt tokens than the model can represent. SGLang is one: it reads at most
+        # ``context_len - 7`` and *silently truncates* anything longer, so a window sized to
+        # ``max_seq_len - 1`` would lose its tail on every chunk and condition the model on a
+        # prefix nobody asked for (issue #171). Backends advertise the limit via an optional
+        # ``max_prompt_len``; ``None`` (and the HF backend, which has no such limit) means
+        # "model context is the only bound", preserving previous behavior.
+        ctx_cap = self.max_seq_len - 1
+        backend_cap = getattr(self._backend, "max_prompt_len", None)
+        if backend_cap is not None:
+            if backend_cap <= 0:
+                raise ValueError(
+                    f"Backend {type(self._backend).__name__} reports max_prompt_len="
+                    f"{backend_cap}; it cannot accept any prompt for a model with "
+                    f"max_seq_len={self.max_seq_len}."
+                )
+            ctx_cap = min(ctx_cap, backend_cap)
+
         if rolling_context_size is None:
-            ctx_size = self.max_seq_len - 1
+            ctx_size = ctx_cap
         else:
             if rolling_context_size <= 0:
                 raise ValueError(f"rolling_context_size must be positive; got {rolling_context_size}.")
-            ctx_size = min(rolling_context_size, self.max_seq_len - 1)
+            ctx_size = min(rolling_context_size, ctx_cap)
 
         input_ids = batch.code
         pad_id = batch.PAD_INDEX

--- a/src/MEDS_EIC_AR/model/model.py
+++ b/src/MEDS_EIC_AR/model/model.py
@@ -903,41 +903,32 @@ class Model(torch.nn.Module):
         # shortening it. Backends advertise that limit via an optional ``max_prompt_len``;
         # ``None`` (the HF backend, which has no such limit) means the model context is the only
         # bound.
-        ctx_cap = self.max_seq_len - 1
         backend_cap = getattr(self._backend, "max_prompt_len", None)
-        if backend_cap is not None:
-            if backend_cap <= 0:
-                raise ValueError(
-                    f"Backend {type(self._backend).__name__} reports max_prompt_len="
-                    f"{backend_cap}; it cannot accept any prompt for a model with "
-                    f"max_seq_len={self.max_seq_len}."
-                )
-            ctx_cap = min(ctx_cap, backend_cap)
+        ctx_cap = self.max_seq_len - 1 if backend_cap is None else min(self.max_seq_len - 1, backend_cap)
 
         if rolling_context_size is None:
             # Unspecified: take the largest window everything involved can honor.
-            ctx_size = ctx_cap
-        else:
-            # Specified: refuse anything unattainable rather than quietly shrinking it, so a run
-            # never conditions on less history than it was told to.
-            if rolling_context_size <= 0:
-                raise ValueError(f"rolling_context_size must be positive; got {rolling_context_size}.")
-            if rolling_context_size > ctx_cap:
-                bound = (
-                    f"the model's context window (max_seq_len={self.max_seq_len}, so at most "
-                    f"{self.max_seq_len - 1})"
-                    if ctx_cap == self.max_seq_len - 1
-                    else (
-                        f"{type(self._backend).__name__}, which reads at most {backend_cap} prompt "
-                        "tokens and silently discards the rest"
-                    )
+            rolling_context_size = ctx_cap
+        elif rolling_context_size <= 0:
+            raise ValueError(f"rolling_context_size must be positive; got {rolling_context_size}.")
+        elif rolling_context_size > ctx_cap:
+            # Refuse anything unattainable rather than quietly shrinking it, so a run never
+            # conditions on less history than it was told to.
+            bound = (
+                f"the model's context window (max_seq_len={self.max_seq_len}, so at most "
+                f"{self.max_seq_len - 1})"
+                if ctx_cap == self.max_seq_len - 1
+                else (
+                    f"{type(self._backend).__name__}, which reads at most {backend_cap} prompt "
+                    "tokens and silently discards the rest"
                 )
-                raise ValueError(
-                    f"rolling_context_size={rolling_context_size} exceeds what is usable here: "
-                    f"{bound}. Lower it to at most {ctx_cap}, or leave it unset to use the "
-                    "largest usable window automatically."
-                )
-            ctx_size = rolling_context_size
+            )
+            raise ValueError(
+                f"rolling_context_size={rolling_context_size} exceeds what is usable here: "
+                f"{bound}. Lower it to at most {ctx_cap}, or leave it unset to use the "
+                "largest usable window automatically."
+            )
+        ctx_size = rolling_context_size
 
         input_ids = batch.code
         pad_id = batch.PAD_INDEX

--- a/tests/test_generate_trajectories.py
+++ b/tests/test_generate_trajectories.py
@@ -406,8 +406,8 @@ def test_collate_with_meta_round_trip_through_dataloader():
 def test_rolling_context_size_above_the_model_window_is_rejected(rolling_model: Model, rolling_batch):
     """An explicitly-set window larger than the model can hold is a config error, not a hint.
 
-    Silently shrinking it would mean the run conditions on less history than it was told to,
-    with nothing in the output to say so.
+    Silently shrinking it would mean the run conditions on less history than it was told to, with nothing in
+    the output to say so.
     """
     with pytest.raises(ValueError, match="exceeds what is usable"):
         _run_rolling(

--- a/tests/test_generate_trajectories.py
+++ b/tests/test_generate_trajectories.py
@@ -401,3 +401,38 @@ def test_collate_with_meta_round_trip_through_dataloader():
     assert all_dataset_row_idxs == expected_dataset_row_idxs
     assert all_trajectory_idxs == expected_trajectory_idxs
     assert all_first_codes == expected_dataset_row_idxs
+
+
+def test_rolling_context_size_above_the_model_window_is_rejected(rolling_model: Model, rolling_batch):
+    """An explicitly-set window larger than the model can hold is a config error, not a hint.
+
+    Silently shrinking it would mean the run conditions on less history than it was told to,
+    with nothing in the output to say so.
+    """
+    with pytest.raises(ValueError, match="exceeds what is usable"):
+        _run_rolling(
+            rolling_model,
+            rolling_batch,
+            max_new_tokens=10,
+            rolling_context_size=rolling_model.max_seq_len + 5,
+        )
+
+
+def test_rolling_context_size_above_a_backend_ceiling_is_rejected(rolling_model: Model, rolling_batch):
+    """Same rule when the binding limit is the backend's, not the model's.
+
+    The error must name the backend, since the model's own context window would have allowed it.
+    """
+
+    class _CappedBackend:
+        max_prompt_len = 4
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def generate_chunk(self, *args, **kwargs):  # pragma: no cover - never reached
+            return self._inner.generate_chunk(*args, **kwargs)
+
+    rolling_model._backend = _CappedBackend(rolling_model._backend)
+    with pytest.raises(ValueError, match="_CappedBackend"):
+        _run_rolling(rolling_model, rolling_batch, max_new_tokens=10, rolling_context_size=8)

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -17,6 +17,7 @@ What's deliberately NOT tested here:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -814,6 +815,11 @@ def test_explicit_flashinfer_below_the_floor_is_refused(tmp_path: Path):
         )
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("sglang") is None,
+    reason="Name validation is defined by sglang's own ATTENTION_BACKEND_CHOICES; without the "
+    "package installed there is no list to validate against and the check is skipped by design.",
+)
 def test_unknown_attention_backend_is_refused(tmp_path: Path):
     """A misspelled backend should fail here, naming the valid choices."""
     _write_config(tmp_path, max_position_embeddings=512, head_dim=128)

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -750,3 +750,24 @@ def test_input_ceiling_is_checked_against_the_longest_prompt_in_the_batch(tmp_pa
                 max_new_tokens=1, do_sample=False, pad_token_id=0, eos_token_id=99
             ),
         )
+
+
+def test_max_prompt_len_prefers_the_engines_reported_ceiling(tmp_path: Path):
+    """When the engine reports ``max_req_input_len``, that wins over the derived fallback.
+
+    The reported value tracks SGLang's own rule across versions and covers the case where the
+    KV pool binds rather than the context length. Minus one because the check is ``>=``.
+    """
+    fake = _FakeSGLModule()
+    (tmp_path / "config.json").write_text(json.dumps({"max_position_embeddings": 512}))
+    backend = SGLangBackend(tmp_path, sgl_module=fake)
+    fake.last_engine.scheduler_info = {"status": "ready", "max_req_input_len": 64}
+    backend._max_prompt_len = backend._resolve_max_prompt_len()
+
+    assert backend.max_prompt_len == 63, "Engine-reported ceiling should win over 512 - 7."
+
+
+def test_max_prompt_len_falls_back_when_the_engine_reports_nothing(tmp_path: Path):
+    """Engines that don't expose ``scheduler_info`` fall back to the documented arithmetic."""
+    backend, _ = _make_backend_with_context(tmp_path, context_len=512)
+    assert backend.max_prompt_len == 512 - _SGLANG_INPUT_RESERVE

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -30,11 +30,17 @@ if TYPE_CHECKING:
 from MEDS_EIC_AR.model.backends import GenerationBackend, SGLangBackend
 from MEDS_EIC_AR.model.backends.sglang import (
     _FLASHINFER_MIN_HEAD_DIM,
-    _SGLANG_CONTEXT_RESERVE,
-    _SGLANG_INPUT_RESERVE,
+    _SGLANG_MAX_REQ_LEN_GAP,
     _pad_right_to_tensor,
     _strip_padding_to_lists,
 )
+
+
+#: What a real engine reports for a model with ``context_len`` positions, when the context length
+#: (rather than the KV pool) is the binding term:
+#: ``max_req_input_len = min(context_len - 1, pool - 1) - _SGLANG_MAX_REQ_LEN_GAP``.
+def _reported_input_len(context_len: int) -> int:
+    return context_len - 1 - _SGLANG_MAX_REQ_LEN_GAP
 
 
 class _FakeEngine:
@@ -44,9 +50,12 @@ class _FakeEngine:
     particular, that HF-only kwargs have been stripped by the backend before reaching here).
     """
 
-    def __init__(self, model_path: str, **engine_kwargs: Any):
+    def __init__(self, model_path: str, max_req_input_len: int = 1_000_000, **engine_kwargs: Any):
         self.model_path = model_path
         self.engine_kwargs = engine_kwargs
+        # Real engines expose this; the backend requires it to know how many prompt tokens will
+        # actually be read. Defaults high so tests that don't care about the ceiling are unaffected.
+        self.scheduler_info = {"status": "ready", "max_req_input_len": max_req_input_len}
         self.generate_calls: list[dict] = []
         # Tests inject what the next ``generate`` call should return.
         self._next_outputs: list[dict] | None = None
@@ -78,11 +87,12 @@ class _FakeEngine:
 class _FakeSGLModule:
     """Matches the tiny surface of the real ``sglang`` module that the backend touches."""
 
-    def __init__(self):
+    def __init__(self, max_req_input_len: int = 1_000_000):
         self.last_engine: _FakeEngine | None = None
+        self.max_req_input_len = max_req_input_len
 
     def Engine(self, *, model_path: str, **engine_kwargs: Any) -> _FakeEngine:  # noqa: N802 — mirrors the real sglang.Engine class name
-        eng = _FakeEngine(model_path=model_path, **engine_kwargs)
+        eng = _FakeEngine(model_path=model_path, max_req_input_len=self.max_req_input_len, **engine_kwargs)
         self.last_engine = eng
         return eng
 
@@ -101,8 +111,8 @@ def _make_backend_with_context(tmp_path: Path, context_len: int) -> tuple[SGLang
     determine a ceiling and leaves budgets alone — which is what keeps the older tests here
     unaffected by the context-window clamp. Tests that exercise the clamp need a readable config.
     """
-    (tmp_path / "config.json").write_text(json.dumps({"max_position_embeddings": context_len}))
-    fake = _FakeSGLModule()
+    _write_config(tmp_path, max_position_embeddings=context_len)
+    fake = _FakeSGLModule(max_req_input_len=_reported_input_len(context_len))
     backend = SGLangBackend(tmp_path, sgl_module=fake)
     return backend, fake
 
@@ -550,7 +560,7 @@ def test_budget_at_the_ceiling_is_passed_through_unchanged(tmp_path: Path):
     two cases an off-by-one in the cap would get wrong.
     """
     backend, fake = _make_backend_with_context(tmp_path, context_len=512)
-    ceiling = 512 - 128 - _SGLANG_CONTEXT_RESERVE
+    ceiling = 512 - 128 - 2
     assert _one_row_call(backend, fake, prompt_len=128, max_new_tokens=ceiling - 1)["max_new_tokens"] == (
         ceiling - 1
     )
@@ -565,7 +575,7 @@ def test_budget_over_the_ceiling_is_clamped_and_logged(tmp_path: Path, caplog: p
     a word. The clamp is now applied here and announced.
     """
     backend, fake = _make_backend_with_context(tmp_path, context_len=512)
-    ceiling = 512 - 128 - _SGLANG_CONTEXT_RESERVE
+    ceiling = 512 - 128 - 2
 
     with caplog.at_level("WARNING"):
         sp = _one_row_call(backend, fake, prompt_len=128, max_new_tokens=384)
@@ -622,19 +632,21 @@ def test_ceiling_uses_the_longest_prompt_in_the_batch(tmp_path: Path):
     backend.generate_chunk(input_ids, attention_mask=attention_mask, generation_config=cfg)
 
     sp = fake.last_engine.generate_calls[-1]["sampling_params"]
-    assert sp["max_new_tokens"] == 64 - 40 - _SGLANG_CONTEXT_RESERVE
+    assert sp["max_new_tokens"] == 64 - 40 - 2
 
 
-def test_unreadable_config_leaves_the_budget_alone(tmp_path: Path):
-    """With no readable ``config.json`` the ceiling is unknown, so the request must pass through.
+def test_budgets_do_not_depend_on_a_readable_config(tmp_path: Path):
+    """An unreadable ``config.json`` costs the head-dim pre-flight, not the ceilings.
 
-    Falling back to the engine's own ``allow_auto_truncate`` is worse than capping proactively, but
-    much better than refusing to construct the backend or guessing a context length.
+    Both ceilings come from the engine, so a missing config no longer leaves the backend guessing about how
+    many tokens it may send or receive.
     """
-    fake = _FakeSGLModule()
+    fake = _FakeSGLModule(max_req_input_len=200)
     backend = SGLangBackend(tmp_path, sgl_module=fake)  # empty dir: no config.json
-    assert backend._context_len is None
-    assert _one_row_call(backend, fake, prompt_len=128, max_new_tokens=100_000)["max_new_tokens"] == 100_000
+
+    assert backend.max_prompt_len == 199
+    sp = _one_row_call(backend, fake, prompt_len=128, max_new_tokens=100_000)
+    assert sp["max_new_tokens"] == 200 + _SGLANG_MAX_REQ_LEN_GAP - 128 - 1
 
 
 # ---------------------------------------------------------------------------
@@ -643,7 +655,12 @@ def test_unreadable_config_leaves_the_budget_alone(tmp_path: Path):
 
 
 def _write_config(tmp_path: Path, **fields: Any) -> Path:
-    (tmp_path / "config.json").write_text(json.dumps(fields))
+    """Write a model config, defaulting ``model_type`` so ``AutoConfig`` can load it.
+
+    ``export_lightning_to_hf_dir`` always writes ``model_type``; a config without one is not a
+    shape the backend ever sees in practice, and ``AutoConfig`` cannot resolve it.
+    """
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "llama", **fields}))
     return tmp_path
 
 
@@ -706,14 +723,28 @@ def test_max_prompt_len_reports_sglangs_real_input_ceiling(tmp_path: Path):
     on a 16-position model a 9-token prompt is honored and a 10-token prompt is truncated.
     """
     backend, _ = _make_backend_with_context(tmp_path, context_len=16)
-    assert backend.max_prompt_len == 16 - _SGLANG_INPUT_RESERVE == 9
+    assert backend.max_prompt_len == 9
 
 
-def test_max_prompt_len_is_none_when_context_is_unknown(tmp_path: Path):
-    """Without a readable context length we must not invent a ceiling."""
+def test_missing_engine_ceiling_raises_rather_than_guessing(tmp_path: Path):
+    """An engine that reports no ``max_req_input_len`` must stop construction.
+
+    Guessing a ceiling here is not safe: too high and the engine silently truncates prompts, and
+    nothing downstream can tell that it happened.
+    """
     fake = _FakeSGLModule()
-    backend = SGLangBackend(tmp_path, sgl_module=fake)  # no config.json written
-    assert backend.max_prompt_len is None
+    fake.max_req_input_len = 1  # `- 1` leaves no room for a prompt
+    with pytest.raises(RuntimeError, match="no room for a prompt"):
+        SGLangBackend(tmp_path, sgl_module=fake)
+
+    class _NoInfoModule(_FakeSGLModule):
+        def Engine(self, *, model_path: str, **engine_kwargs: Any):  # noqa: N802
+            eng = super().Engine(model_path=model_path, **engine_kwargs)
+            del eng.scheduler_info
+            return eng
+
+    with pytest.raises(RuntimeError, match="did not report a usable"):
+        SGLangBackend(tmp_path, sgl_module=_NoInfoModule())
 
 
 def test_prompt_over_the_input_ceiling_raises_instead_of_being_truncated(tmp_path: Path):
@@ -752,22 +783,50 @@ def test_input_ceiling_is_checked_against_the_longest_prompt_in_the_batch(tmp_pa
         )
 
 
-def test_max_prompt_len_prefers_the_engines_reported_ceiling(tmp_path: Path):
-    """When the engine reports ``max_req_input_len``, that wins over the derived fallback.
+def test_ceilings_are_derived_from_the_engines_reported_value(tmp_path: Path):
+    """Both ceilings follow from ``scheduler_info``, not from the model config.
 
-    The reported value tracks SGLang's own rule across versions and covers the case where the
-    KV pool binds rather than the context length. Minus one because the check is ``>=``.
+    That is what keeps them right when the KV pool binds instead of the context length, a case
+    no config-file arithmetic can see. The prompt ceiling is one below the reported value (the
+    engine's check is ``>=``); the output ceiling follows from ``max_req_len``.
     """
-    fake = _FakeSGLModule()
     (tmp_path / "config.json").write_text(json.dumps({"max_position_embeddings": 512}))
+    # Deliberately inconsistent with the config: a pool-bound engine reports far less.
+    fake = _FakeSGLModule(max_req_input_len=64)
     backend = SGLangBackend(tmp_path, sgl_module=fake)
-    fake.last_engine.scheduler_info = {"status": "ready", "max_req_input_len": 64}
-    backend._max_prompt_len = backend._resolve_max_prompt_len()
 
-    assert backend.max_prompt_len == 63, "Engine-reported ceiling should win over 512 - 7."
+    assert backend.max_prompt_len == 63, "Prompt ceiling should track the engine, not the config."
+
+    sp = _one_row_call(backend, fake, prompt_len=40, max_new_tokens=1000)
+    assert sp["max_new_tokens"] == 64 + _SGLANG_MAX_REQ_LEN_GAP - 40 - 1
 
 
-def test_max_prompt_len_falls_back_when_the_engine_reports_nothing(tmp_path: Path):
-    """Engines that don't expose ``scheduler_info`` fall back to the documented arithmetic."""
-    backend, _ = _make_backend_with_context(tmp_path, context_len=512)
-    assert backend.max_prompt_len == 512 - _SGLANG_INPUT_RESERVE
+def test_explicit_flashinfer_below_the_floor_is_refused(tmp_path: Path):
+    """Naming FlashInfer explicitly does not make it dispatch a narrow head dim.
+
+    The floor is FlashInfer's, so it applies however FlashInfer came to be selected; deferring to an explicit
+    choice here would just hand back the exit -9 the check exists to prevent.
+    """
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=32)
+    with pytest.raises(ValueError, match="explicitly selected"):
+        SGLangBackend(
+            tmp_path, engine_kwargs={"attention_backend": "flashinfer"}, sgl_module=_FakeSGLModule()
+        )
+
+
+def test_unknown_attention_backend_is_refused(tmp_path: Path):
+    """A misspelled backend should fail here, naming the valid choices."""
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=128)
+    with pytest.raises(ValueError, match="Unknown SGLang attention_backend"):
+        SGLangBackend(
+            tmp_path, engine_kwargs={"attention_backend": "flashinfer_typo"}, sgl_module=_FakeSGLModule()
+        )
+
+
+def test_non_flashinfer_backend_below_the_floor_is_allowed(tmp_path: Path):
+    """Backends without FlashInfer's floor must not inherit its restriction."""
+    _write_config(tmp_path, max_position_embeddings=512, head_dim=32)
+    backend = SGLangBackend(
+        tmp_path, engine_kwargs={"attention_backend": "triton"}, sgl_module=_FakeSGLModule()
+    )
+    assert backend._engine_kwargs["attention_backend"] == "triton"

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -31,6 +31,7 @@ from MEDS_EIC_AR.model.backends import GenerationBackend, SGLangBackend
 from MEDS_EIC_AR.model.backends.sglang import (
     _FLASHINFER_MIN_HEAD_DIM,
     _SGLANG_CONTEXT_RESERVE,
+    _SGLANG_INPUT_RESERVE,
     _pad_right_to_tensor,
     _strip_padding_to_lists,
 )
@@ -695,3 +696,57 @@ def test_unknown_head_dim_does_not_block_construction(tmp_path: Path):
     """
     _write_config(tmp_path, max_position_embeddings=512)
     SGLangBackend(tmp_path, sgl_module=_FakeSGLModule())
+
+
+def test_max_prompt_len_reports_sglangs_real_input_ceiling(tmp_path: Path):
+    """The advertised ceiling is ``context_len - 7``, matching SGLang's own arithmetic.
+
+    ``max_req_input_len = min(context_len - 1, kv_pool - 1) - 5`` and the length check is ``>=``,
+    so the longest prompt read in full is ``context_len - 7``. Verified against a live engine:
+    on a 16-position model a 9-token prompt is honored and a 10-token prompt is truncated.
+    """
+    backend, _ = _make_backend_with_context(tmp_path, context_len=16)
+    assert backend.max_prompt_len == 16 - _SGLANG_INPUT_RESERVE == 9
+
+
+def test_max_prompt_len_is_none_when_context_is_unknown(tmp_path: Path):
+    """Without a readable context length we must not invent a ceiling."""
+    fake = _FakeSGLModule()
+    backend = SGLangBackend(tmp_path, sgl_module=fake)  # no config.json written
+    assert backend.max_prompt_len is None
+
+
+def test_prompt_over_the_input_ceiling_raises_instead_of_being_truncated(tmp_path: Path):
+    """The reported defect (#171): SGLang silently drops the prompt tail past its input cap.
+
+    It does not reject the request and the returned shape looks correct, so the corruption is
+    invisible -- it surfaced only as grammar-invalid trajectories. Refuse loudly instead.
+    """
+    backend, fake = _make_backend_with_context(tmp_path, context_len=16)
+    with pytest.raises(ValueError, match="silently truncate"):
+        _one_row_call(backend, fake, prompt_len=10, max_new_tokens=1)
+
+
+def test_prompt_at_the_input_ceiling_is_accepted(tmp_path: Path):
+    """The boundary itself must still work -- the cap is inclusive of ``context_len - 7``."""
+    backend, fake = _make_backend_with_context(tmp_path, context_len=16)
+    sp = _one_row_call(backend, fake, prompt_len=9, max_new_tokens=1)
+    assert sp["max_new_tokens"] == 1
+
+
+def test_input_ceiling_is_checked_against_the_longest_prompt_in_the_batch(tmp_path: Path):
+    """``max_new_tokens`` is shared across the call, and so is the input ceiling check."""
+    backend, fake = _make_backend_with_context(tmp_path, context_len=16)
+    ids = torch.zeros((2, 12), dtype=torch.long)
+    mask = torch.zeros((2, 12), dtype=torch.bool)
+    mask[0, -4:] = True  # 4 real tokens: fine
+    mask[1, -11:] = True  # 11 real tokens: over the ceiling
+    fake.last_engine = None
+    with pytest.raises(ValueError, match="11-token prompt"):
+        backend.generate_chunk(
+            ids,
+            attention_mask=mask,
+            generation_config=GenerationConfig(
+                max_new_tokens=1, do_sample=False, pad_token_id=0, eos_token_id=99
+            ),
+        )


### PR DESCRIPTION
Closes #171.

## The bug

SGLang reads at most `context_len - 7` prompt tokens. Past that it **does not reject the request** — it drops the tail of the prompt and generates from the remaining prefix. The returned tensor has the right shape and the right number of new tokens, so nothing at the API surface indicates that the model was conditioned on something the caller never asked for.

From `sglang==0.5.9`:

```
max_req_len       = min(context_len - 1, kv_pool - 1)     # managers/tp_worker.py:288
max_req_input_len = max_req_len - 5                       # managers/tp_worker.py:291
if len(origin_input_ids) >= max_req_input_len:            # managers/utils.py:111
    truncate (allow_auto_truncate) else reject
```

The comparison is `>=`, so the longest prompt read in full is `context_len - 7`. Confirmed against a live engine on a 16-position model: a 9-token prompt is honored, a 10-token prompt is not. With `allow_auto_truncate=False` the engine says so outright:

```
ValueError: Input length (11 tokens) exceeds the maximum allowed length (10 tokens).
```

Two things kept it silent:

1. `SGLangBackend` sets `allow_auto_truncate=True` unconditionally, which converts that rejection into a truncation.
2. SGLang *does* log a warning when it truncates — through a logger its own engine init has already set to ERROR (`ServerArgs.log_level` defaults to `'error'` and is applied process-wide). So the warning never appears.

`Model._rolling_generate` defaults its window to `max_seq_len - 1`, which is far above the ceiling, so **every** rolling chunk lost its prompt tail.

## Impact

On the grammar fixture (16-position model, window 15 vs ceiling 9), same checkpoint, greedy:

| backend | output | grammar-invalid |
| --- | --- | ---: |
| HF | `[2,3,4,5,1, 2,3,4,5,1, 2,3,4,5,1]` | 0 / 128 |
| SGLang (before) | `[2,3,4,5,1, 5,1, 2,2,2,3,3,4,4,4]` | **128 / 128** |

The degenerate tail is the model being re-fed a truncated prefix each chunk.

## The fix

Backends may advertise an optional `max_prompt_len`. `SGLangBackend` computes it from the model's context length; the HF backend advertises nothing and is unaffected.

- `Model._rolling_generate` clamps its window to that ceiling, so the default configuration is correct with no user intervention.
- `SGLangBackend.generate_chunk` refuses an over-long prompt with an error naming the ceiling and the remedy, rather than letting the engine quietly discard part of it. Silent corruption becomes a loud failure for any caller that builds its own prompt window.

## What this is *not*

Not a greedy-vs-sampling difference. Greedy decoding was correct throughout on prompts that fit. Per-chunk parity with the HF backend is **exact** below the ceiling — measured for uniform prompts, one-token-at-a-time decoding, and left-padded variable-length batches. Not the attention backend either: `triton` and `torch_native` fail identically, and `head_dim=32` vs `64` makes no difference.

## Relationship to #168

Same base quantity, different derived limit — adjacent but distinct:

| | formula | effect |
| --- | --- | --- |
| #168 (output) | `min(requested, max_req_len - len(input) - 1)` = `context_len - len(input) - 2` | 2 fewer tokens emitted; output still correct |
| this (input) | `max_req_input_len = max_req_len - 5`, checked with `>=` | prompt silently altered; output *wrong* |

Both descend from `max_req_len = min(context_len - 1, kv_pool - 1)`, which is why the constants look related. #168's analysis was correct but stopped at the output side.

Worth noting this also makes #168's `allowed <= 0` error unreachable from the rolling loop: once the window is clamped to `context_len - 7`, the output budget is always `>= 5`. That was the failure that made the gated test error out on that branch.

## Verification

DGX Spark (GB10, SM 12.1), `sglang==0.5.9`, `sgl-kernel==0.3.21+cu130`, `torch==2.9.1+cu129`:

- `tests/grammar/test_cli_sglang.py` — **passes** with default settings (was failing). SGLang's output is byte-identical to HF's, 0/128 grammar-invalid.
- `tests/test_sglang_backend.py` — 37 passed, including 5 new tests covering the ceiling, the boundary, the unknown-context case, and the longest-prompt-in-batch case.
- Rest of the suite (`tests/`, `src/` doctests, excluding `tests/grammar`) — 126 passed, 4 skipped.

Branched off `fix/sglang-head-dim-and-mem-163` (top of the #167/#168/#169 stack), since it builds on #168's context-ceiling work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuRZgDxXbTXbZCtFo2hHdy
